### PR TITLE
[#9] Chore: tailwind px to rem

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -47,10 +47,6 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
   }
-
-  html {
-    font-size: 62.5%;
-  }
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,10 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
   }
+
+  html {
+    font-size: 100%;
+  }
 }
 
 @layer base {
@@ -58,6 +62,7 @@
     /* font-feature-settings: "rlig" 1, "calt" 1; */
     font-synthesis-weight: none;
     text-rendering: optimizeLegibility;
+    font-size: 16px;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,13 +18,13 @@ export default {
         "2xl": "1400px",
       },
     },
-    spacing: {
-      ...range(1, 100).reduce((accumulate, px) => {
-        accumulate[`${px}pxr`] = pxToRem(px);
-        return accumulate;
-      }, {}),
-    },
     extend: {
+      spacing: {
+        ...range(1, 100).reduce((accumulate, px) => {
+          accumulate[`${px}pxr`] = pxToRem(px);
+          return accumulate;
+        }, {}),
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,11 @@
 /** @type {import('tailwindcss').Config} */
+
+const pxToRem = (px, base = 16) => `${px / base}rem`;
+
+const range = (start, end) => {
+  return Array.from({ length: end - start + 1 }, (_, index) => index + start);
+};
+
 export default {
   darkMode: ["class"],
   content: ["./src/**/*.{ts,tsx}"],
@@ -11,10 +18,13 @@ export default {
         "2xl": "1400px",
       },
     },
+    spacing: {
+      ...range(1, 100).reduce((accumulate, px) => {
+        accumulate[`${px}pxr`] = pxToRem(px);
+        return accumulate;
+      }, {}),
+    },
     extend: {
-      fontSize: {
-        base: "62.5%",
-      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ export default {
     },
     extend: {
       spacing: {
-        ...range(1, 100).reduce((accumulate, px) => {
+        ...range(1, 1400).reduce((accumulate, px) => {
           accumulate[`${px}pxr`] = pxToRem(px);
           return accumulate;
         }, {}),


### PR DESCRIPTION
## 📝작업 내용
pxr이라는 새로운 단위를 만들었습니다. 이 작업의 배경과 이점은 다음과 같습니다:
개발 시에는 px 단위가 더 편리합니다:

- 디자이너와 소통할 때 시안의 값을 그대로 사용할 수 있어 의사소통이 원활
- 직관적인 수치로 개발 생산성이 높음
- 계산 없이 바로 적용 가능

하지만 실제 서비스에서는 rem 단위가 더 좋습니다:

- 사용자의 브라우저 폰트 크기 설정을 반영하여 접근성 향상
- 다양한 디바이스에서 유동적인 크기 조정 가능
- 시각 장애인들의 브라우저 설정을 존중하여 더 나은 사용자 경험 제공

이러한 trade-off를 해결하기 위해 pxr 단위를 도입했습니다.

이제부터 단위를 작성하실때 기존 방법 (10px === 1rem)`w-[1rem]` 대신 `w-10pxr`을 사용해주시면 됩니다.
`pxr`은 `px`과 동일하다고 생각하시면 됩니다.