### PR TITLE
[#13] Chore: commit lint 오타 수정

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -18,7 +18,7 @@ module.exports = {
       // 아래의 type만 사용 가능
       2,
       "always",
-      ["Feat", "Fix", "Docs", "Style", "Refactor", "Test", "Chore", "Modify", "Rename", "Clanup"],
+      ["Feat", "Fix", "Docs", "Style", "Refactor", "Test", "Chore", "Modify", "Rename", "Cleanup"],
     ],
   },
 };


### PR DESCRIPTION
## 📝작업 내용

commit lint config에서 `Cleanup` 키워드가 `Clanup`으로 되어있어 오타 수정했습니다.