### PR TITLE
[#16] Feat: 회원가입 로직 구현

### DIFF
--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -7,12 +7,12 @@ export interface LoginRequest {
   password: string;
 }
 
-export interface LoginResponse {
+export interface AuthResponse {
   user: User;
   token: string;
 }
 
-const postLogin = (loginInfo: LoginRequest) =>
-  api.post<LoginResponse>({ url: "/login", data: loginInfo });
+export const postLogin = (loginInfo: LoginRequest) =>
+  api.post<AuthResponse>({ url: "/login", data: loginInfo });
 
 export default postLogin;

--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -7,6 +7,10 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface RegisterRequest extends LoginRequest {
+  fullName: string;
+}
+
 export interface AuthResponse {
   user: User;
   token: string;
@@ -15,4 +19,5 @@ export interface AuthResponse {
 export const postLogin = (loginInfo: LoginRequest) =>
   api.post<AuthResponse>({ url: "/login", data: loginInfo });
 
-export default postLogin;
+export const postRegister = (registerInfo: RegisterRequest) =>
+  api.post<AuthResponse>({ url: "/signup", data: registerInfo });

--- a/src/apis/auth/useLogin.ts
+++ b/src/apis/auth/useLogin.ts
@@ -4,12 +4,12 @@ import useUserStore from "@/stores/user";
 
 import { setLocalStorage } from "@/utils/localStorage";
 
-import postLogin, { LoginRequest, LoginResponse } from "./queryFn";
+import { postLogin, LoginRequest, AuthResponse } from "./queryFn";
 
 const useLogin = () => {
   const { updateUser } = useUserStore();
 
-  const parseUser = (data: LoginResponse) => {
+  const parseUser = (data: AuthResponse) => {
     const {
       token,
       user: { _id: id, email, fullName },

--- a/src/apis/auth/useRegister.ts
+++ b/src/apis/auth/useRegister.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { postRegister, RegisterRequest } from "./queryFn";
+
+const useRegister = () => {
+  return useMutation({
+    mutationFn: (body: RegisterRequest) => postRegister(body),
+  });
+};
+
+export default useRegister;

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -26,7 +26,7 @@ export interface FieldProps {
    * <input>의 autocomplete 속성 문서 참고:
    * @see https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/
    */
-  autoComplete?: "username" | "current-password" | "new-password" | "nickname";
+  autoComplete?: "username" | "current-password" | "new-password" | "nickname" | "off";
 }
 
 export interface SimpleFormProps {

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -32,7 +32,7 @@ export interface FieldProps {
 export interface SimpleFormProps {
   fields: FieldProps[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  validationSchema: z.ZodObject<any>;
+  validationSchema: z.ZodEffects<z.ZodObject<any>> | z.ZodObject<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSubmit: (values: any) => void;
   submitText: string;

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -26,7 +26,7 @@ export interface FieldProps {
    * <input>의 autocomplete 속성 문서 참고:
    * @see https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/
    */
-  autoComplete?: "username" | "current-password" | "new-password";
+  autoComplete?: "username" | "current-password" | "new-password" | "nickname";
 }
 
 export interface SimpleFormProps {

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
-  const { mutate: mutateLogin } = useLogin();
+  const { mutate: loginMutate } = useLogin();
 
   const handleRegisterClick = () => {
     toggleOpen(!open);
@@ -25,7 +25,7 @@ const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
 
   const handleSubmit = (loginInfo: z.infer<typeof LOGIN_FIELDS_SCHEMA>) => {
     // TODO: 에러 모달 처리 (2024-01-01)
-    mutateLogin(loginInfo);
+    loginMutate(loginInfo);
   };
 
   return (

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -24,6 +24,7 @@ const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
   };
 
   const handleSubmit = (loginInfo: z.infer<typeof LOGIN_FIELDS_SCHEMA>) => {
+    // TODO: 에러 모달 처리 (2024-01-01)
     mutateLogin(loginInfo);
   };
 

--- a/src/components/Layout/Modals/Register/config.ts
+++ b/src/components/Layout/Modals/Register/config.ts
@@ -8,6 +8,7 @@ export const REGISTER_FIELDS: FieldProps[] = [
     type: "text",
     label: "이름",
     autoFocus: true,
+    autoComplete: "off",
   },
   {
     name: "email",

--- a/src/components/Layout/Modals/Register/config.ts
+++ b/src/components/Layout/Modals/Register/config.ts
@@ -16,6 +16,12 @@ export const REGISTER_FIELDS: FieldProps[] = [
     autoComplete: "username",
   },
   {
+    name: "nickname",
+    type: "text",
+    label: "닉네임(선택)",
+    placeholder: "미기입 시 프롱이로 설정됩니다.",
+  },
+  {
     name: "password",
     type: "password",
     label: "비밀번호",
@@ -33,6 +39,7 @@ export const REGISTER_FIELDS_SCHEMA = z.object({
       message: "이메일을 입력해주세요",
     })
     .email("이메일 형식이 아닙니다"),
+  nickname: z.string().trim(),
   password: z.string().min(8, {
     message: "비밀번호는 8글자 이상이어야 합니다",
   }),

--- a/src/components/Layout/Modals/Register/config.ts
+++ b/src/components/Layout/Modals/Register/config.ts
@@ -27,20 +27,32 @@ export const REGISTER_FIELDS: FieldProps[] = [
     label: "비밀번호",
     autoComplete: "new-password",
   },
+  {
+    name: "passwordConfirm",
+    type: "password",
+    label: "비밀번호 확인",
+    autoComplete: "new-password",
+  },
 ];
 
-export const REGISTER_FIELDS_SCHEMA = z.object({
-  name: z.string().min(1, {
-    message: "이름을 입력해주세요",
-  }),
-  email: z
-    .string()
-    .min(1, {
-      message: "이메일을 입력해주세요",
-    })
-    .email("이메일 형식이 아닙니다"),
-  nickname: z.string().trim(),
-  password: z.string().min(8, {
-    message: "비밀번호는 8글자 이상이어야 합니다",
-  }),
-});
+export const REGISTER_FIELDS_SCHEMA = z
+  .object({
+    name: z.string().min(1, {
+      message: "이름을 입력해주세요",
+    }),
+    email: z
+      .string()
+      .min(1, {
+        message: "이메일을 입력해주세요",
+      })
+      .email("이메일 형식이 아닙니다"),
+    nickname: z.string().trim(),
+    password: z.string().min(8, {
+      message: "비밀번호는 8글자 이상이어야 합니다",
+    }),
+    passwordConfirm: z.string(),
+  })
+  .refine(({ password, passwordConfirm }) => password === passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  });

--- a/src/components/Layout/Modals/Register/config.ts
+++ b/src/components/Layout/Modals/Register/config.ts
@@ -20,6 +20,7 @@ export const REGISTER_FIELDS: FieldProps[] = [
     type: "text",
     label: "닉네임(선택)",
     placeholder: "미기입 시 프롱이로 설정됩니다.",
+    autoComplete: "nickname",
   },
   {
     name: "password",

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
 
@@ -7,6 +8,8 @@ import SimpleBaseModal from "../Base/modal";
 
 import { REGISTER_FIELDS, REGISTER_FIELDS_SCHEMA } from "./config";
 
+import useRegister from "@/apis/auth/useRegister";
+
 interface Props {
   open: boolean;
   toggleOpen: (open: boolean) => void;
@@ -14,14 +17,23 @@ interface Props {
 }
 
 const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
+  const register = useRegister();
+
   const handleLoginClick = () => {
     toggleOpen(!open);
     openLoginModal(true);
   };
 
-  const handleSubmit = (values: z.infer<typeof REGISTER_FIELDS_SCHEMA>) => {
-    // TODO: [2023-12-30] 회원가입 API 연동하기
-    console.log(values);
+  const handleSubmit = (registerInfo: z.infer<typeof REGISTER_FIELDS_SCHEMA>) => {
+    const { email, name, nickname, password } = registerInfo;
+    const fullName = JSON.stringify({ name, nickname: nickname || "프롱이" });
+    register.mutate({ email, fullName, password });
+    if (register.isSuccess) handleLoginClick();
+    if (register.isError) {
+      // TODO: 에러 처리 및 타입 단언 개선 (2024-01-01)
+      const error = register.error as AxiosError<string>;
+      alert(error.response?.data);
+    }
   };
 
   return (

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { isAxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
@@ -25,6 +25,11 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     error: registerError,
   } = useRegister();
 
+  const handleLoginClick = useCallback(() => {
+    toggleOpen(!open);
+    openLoginModal(true);
+  }, [open, toggleOpen, openLoginModal]);
+
   useEffect(() => {
     if (isRegisterSuccess) handleLoginClick();
     if (isRegisterError) {
@@ -33,13 +38,7 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
         alert(registerError.response?.data || "An unknown error occurred");
       } else alert("An unknown error occurred");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isRegisterSuccess, isRegisterError]);
-
-  const handleLoginClick = () => {
-    toggleOpen(!open);
-    openLoginModal(true);
-  };
+  }, [isRegisterSuccess, isRegisterError, registerError, handleLoginClick]);
 
   const handleSubmit = (registerInfo: z.infer<typeof REGISTER_FIELDS_SCHEMA>) => {
     const { email, name, nickname, password } = registerInfo;

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -17,7 +17,13 @@ interface Props {
 }
 
 const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
-  const { mutate: registerMutate, isSuccess, isError, error } = useRegister();
+  const {
+    mutate: registerMutate,
+    isSuccess: isRegisterSuccess,
+    isError: isRegisterError,
+    error: registerError,
+  } = useRegister();
+
 
   const handleLoginClick = () => {
     toggleOpen(!open);

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -30,7 +30,7 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     register.mutate({ email, fullName, password });
     if (register.isSuccess) handleLoginClick();
     if (register.isError) {
-      // TODO: 에러 처리 및 타입 단언 개선 (2024-01-01)
+      // TODO: 에러 모달 처리 (2024-01-01)
       if (isAxiosError(register.error)) {
         const { response } = register.error;
         alert(response?.data || "An unknown error occurred");

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -27,7 +27,7 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
   const handleSubmit = (registerInfo: z.infer<typeof REGISTER_FIELDS_SCHEMA>) => {
     const { email, name, nickname, password } = registerInfo;
     const fullName = JSON.stringify({ name, nickname: nickname || "프롱이" });
-    register.mutate({ email, fullName, password });
+    registerMutate({ email, fullName, password });
     if (isSuccess) handleLoginClick();
     if (isError) {
       // TODO: 에러 모달 처리 (2024-01-01)

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { useEffect } from "react";
 import { isAxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,16 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     error: registerError,
   } = useRegister();
 
+  useEffect(() => {
+    if (isRegisterSuccess) handleLoginClick();
+    if (isRegisterError) {
+      // TODO: 에러 모달 처리 (2024-01-01)
+      if (isAxiosError(registerError)) {
+        alert(registerError.response?.data || "An unknown error occurred");
+      } else alert("An unknown error occurred");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRegisterSuccess, isRegisterError]);
 
   const handleLoginClick = () => {
     toggleOpen(!open);
@@ -34,12 +45,6 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     const { email, name, nickname, password } = registerInfo;
     const fullName = JSON.stringify({ name, nickname: nickname || "프롱이" });
     registerMutate({ email, fullName, password });
-    if (isSuccess) handleLoginClick();
-    if (isError) {
-      // TODO: 에러 모달 처리 (2024-01-01)
-      if (isAxiosError(error)) alert(error.response?.data || "An unknown error occurred");
-      else alert("An unknown error occurred");
-    }
   };
 
   return (

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { AxiosError } from "axios";
+import { isAxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
 
@@ -31,8 +31,10 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     if (register.isSuccess) handleLoginClick();
     if (register.isError) {
       // TODO: 에러 처리 및 타입 단언 개선 (2024-01-01)
-      const error = register.error as AxiosError<string>;
-      alert(error.response?.data);
+      if (isAxiosError(register.error)) {
+        const { response } = register.error;
+        alert(response?.data || "An unknown error occurred");
+      } else alert("An unknown error occurred");
     }
   };
 

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
-  const register = useRegister();
+  const { mutate: registerMutate, isSuccess, isError, error } = useRegister();
 
   const handleLoginClick = () => {
     toggleOpen(!open);
@@ -28,13 +28,11 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     const { email, name, nickname, password } = registerInfo;
     const fullName = JSON.stringify({ name, nickname: nickname || "프롱이" });
     register.mutate({ email, fullName, password });
-    if (register.isSuccess) handleLoginClick();
-    if (register.isError) {
+    if (isSuccess) handleLoginClick();
+    if (isError) {
       // TODO: 에러 모달 처리 (2024-01-01)
-      if (isAxiosError(register.error)) {
-        const { response } = register.error;
-        alert(response?.data || "An unknown error occurred");
-      } else alert("An unknown error occurred");
+      if (isAxiosError(error)) alert(error.response?.data || "An unknown error occurred");
+      else alert("An unknown error occurred");
     }
   };
 

--- a/src/components/common/Mention/MentionInput.tsx
+++ b/src/components/common/Mention/MentionInput.tsx
@@ -2,8 +2,8 @@ import { FormEvent, useRef, useState, KeyboardEvent, useEffect } from "react";
 
 import { Input } from "@/components/ui/input.tsx";
 
-import AutoCompleteMentionList from "@/components/common/Mention/AutoCompleteMentionList.tsx";
-import UserBadgeList from "@/components/common/Mention/UserBadgeList.tsx";
+import AutoCompleteMentionList from "@/components/common/Mention/AutoCompleteMentionList";
+import UserBadgeList from "@/components/common/Mention/UserBadgeList";
 import autoComplete from "@/lib/autoComplete.ts";
 import { MyType, USER_LIST } from "@/constants/dummyData.ts";
 

--- a/src/components/common/Mention/UserBadgeList.tsx
+++ b/src/components/common/Mention/UserBadgeList.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge.tsx";
 
-import { ListProps } from "@/components/common/Mention/AutoCompleteMentionList.tsx";
+import { ListProps } from "@/components/common/Mention/AutoCompleteMentionList";
 
 const UserBadgeList = ({ users, onClick }: ListProps) => {
   if (!users.length) return "";


### PR DESCRIPTION
## 📝 작업 내용

- 회원가입 폼에 닉네임 인풋 추가
- 비밀번호 확인 인풋 추가 및 비밀번호와 비밀번호 확인 값 같은지 검사 추가
- 회원가입 api 구현 및 연결
- 회원가입 성공 시 로그인 모달 띄우기, 실패 시 alert 창 띄우기

**작업내용 외 전달 사항**

- 에러 처리는 상세하게 구현하지 않았습니다. (후에 common modal 같은거 적용 생각 중 입니다!)
- 인풋 유효성 검사는 성빈님이 구현해주신 것을 그대로 사용했습니다.
- 프로필 이미지 첨부는 회원가입 api request body에 없어 구현하지 않습니다. 프로필 이미지 변경 api만 있는데 여기에 토큰 값이 필요하여 회원가입 때는 구현이 필요 없고 프로필 정보 변경 때 구현해야할 것 같다고 생각했습니다.!

## 💬 리뷰 요구사항

- 질문 사항

에러 처리를 간단하게 하던 도중 아래와 같은 에러가 발생했습니다! 
`AxiosError` 타입을 이용하여 에러 객체를 정의하고 있는데 `isAxiosError`, `toJSON` 프로퍼티가 없다고(?) 하는 것 같은데 이를 어떻게 해결해야할지 모르겠습니다..! 그래서 우선은 타입 단언으로 해결했습니다 ..!

```ts
// src/components/Layout/Modals/Register/index.tsx
// line 32

const register = useRegister();
const error: AxiosError<string> = register.error;
alert(error.response?.data);

// Error
// Type 'Error' is missing the following properties from type 'AxiosError<string, any>': isAxiosError, toJSON
```
```js
// register.error 콘솔로 찍었을 때 나오는 에러 객체
{
    "message": "Request failed with status code 400",
    "name": "AxiosError",
    "stack": "AxiosError: Request failed with status code 400\n   …”,
    "config": { … },
    "code": "ERR_BAD_REQUEST",
    "status": 400,
    "request": XMLHttpRequest { … },
    "response": {
        "data": "The email address is already being used.",
        "status": 400,
        "statusText": "",
        "headers": {
            "content-length": "40",
            "content-type": "text/html; charset=utf-8"
        },
        "config": { ...,
            "baseURL": "https://kdt.frontend.5th.programmers.co.kr:5002",
            "url": "/signup",
            "data": "{\"email\":\"gye04056@naver.com\",\"fullName\":\"{\\\"name\\\":\\\"ㅁㅁ\\\",\\\"nickname\\\":\\\"프롱이\\\"}\",\"password\":\"ㅇㄴafasdfdafda\"}",
            "method": "post"
        },
        "request": {}
    }
}
```

close #16 
