### PR TITLE
[#36] Feat: 로그인 후 새로고침 했을 때 유저 정보 다시 불러오는 로직 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,26 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
 
 import HomePage from "./pages/Home";
 import MyThreadsPage from "./pages/MyThreads";
 import MyNotificationsPage from "./pages/MyNotifications";
 import NotFoundPage from "./pages/NotFound";
 import Layout from "./components/Layout";
+import useUserStore from "./stores/user";
+import useGetUserInfo from "./apis/auth/useGetUserInfo";
+import { getLocalStorage } from "./utils/localStorage";
 
 const App = () => {
+  const { user, updateUser } = useUserStore();
+  const token = getLocalStorage("token", "");
+  const userInfo = useGetUserInfo(user === null, token);
 
+  useEffect(() => {
+    if (!userInfo) return;
+    if (!user) updateUser(userInfo);
+  }, [userInfo, updateUser, user]);
+
+  return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Layout />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import HomePage from "./pages/Home";
 import MyThreadsPage from "./pages/MyThreads";
@@ -8,11 +6,8 @@ import MyNotificationsPage from "./pages/MyNotifications";
 import NotFoundPage from "./pages/NotFound";
 import Layout from "./components/Layout";
 
-const queryClient = new QueryClient();
+const App = () => {
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <ReactQueryDevtools initialIsOpen={false} />
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Layout />}>
@@ -24,7 +19,7 @@ const App = () => (
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
-  </QueryClientProvider>
-);
+  );
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,23 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { useEffect } from "react";
 
 import HomePage from "./pages/Home";
 import MyThreadsPage from "./pages/MyThreads";
 import MyNotificationsPage from "./pages/MyNotifications";
 import NotFoundPage from "./pages/NotFound";
 import Layout from "./components/Layout";
-import useUserStore from "./stores/user";
-import useGetUserInfo from "./apis/auth/useGetUserInfo";
-import { getLocalStorage } from "./utils/localStorage";
 
-const App = () => {
-  const { user, updateUser } = useUserStore();
-  const token = getLocalStorage("token", "");
-  const userInfo = useGetUserInfo(user === null, token);
-
-  useEffect(() => {
-    if (!userInfo) return;
-    if (!user) updateUser(userInfo);
-  }, [userInfo, updateUser, user]);
-
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<HomePage />} />
-          <Route path="channels/*" element={<HomePage />} />
-          <Route path="my-threads" element={<MyThreadsPage />} />
-          <Route path="my-notifications" element={<MyNotificationsPage />} />
-        </Route>
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </BrowserRouter>
-  );
-};
+const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<HomePage />} />
+        <Route path="channels/*" element={<HomePage />} />
+        <Route path="my-threads" element={<MyThreadsPage />} />
+        <Route path="my-notifications" element={<MyNotificationsPage />} />
+      </Route>
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  </BrowserRouter>
+);
 
 export default App;

--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -21,3 +21,5 @@ export const postLogin = (loginInfo: LoginRequest) =>
 
 export const postRegister = (registerInfo: RegisterRequest) =>
   api.post<AuthResponse>({ url: "/signup", data: registerInfo });
+
+export const getUserInfo = () => api.get<User>({ url: "/auth-user" });

--- a/src/apis/auth/queryKey.ts
+++ b/src/apis/auth/queryKey.ts
@@ -1,0 +1,13 @@
+import { createQueryKeys } from "@lukemorales/query-key-factory";
+
+import { getUserInfo } from "./queryFn";
+
+const auth = createQueryKeys("auth", {
+  userInfo: (isInvalidUserId, token) => ({
+    queryKey: [token],
+    queryFn: getUserInfo,
+    enabled: isInvalidUserId && token !== "",
+  }),
+});
+
+export default auth;

--- a/src/apis/auth/queryKey.ts
+++ b/src/apis/auth/queryKey.ts
@@ -3,10 +3,10 @@ import { createQueryKeys } from "@lukemorales/query-key-factory";
 import { getUserInfo } from "./queryFn";
 
 const auth = createQueryKeys("auth", {
-  userInfo: (isInvalidUserId, token) => ({
+  userInfo: (token: string) => ({
     queryKey: [token],
     queryFn: getUserInfo,
-    enabled: isInvalidUserId && token !== "",
+    enabled: !!token
   }),
 });
 

--- a/src/apis/auth/useGetUserInfo.ts
+++ b/src/apis/auth/useGetUserInfo.ts
@@ -1,16 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { parseFullName } from "@/utils/parsingJson";
 
 import auth from "./queryKey";
 
 const useGetUserInfo = (isInvalidUserId: boolean, token: string) => {
-  const { data, isLoading } = useQuery(auth.userInfo(isInvalidUserId, token));
-  if (!data || isLoading) return;
-
-  const { _id: id, email, fullName } = data;
-  const { name, nickname } = parseFullName(fullName);
-  return { id, email, name, nickname, token, isLoggedIn: true };
+  return useQuery(auth.userInfo(isInvalidUserId, token));
 };
 
 export default useGetUserInfo;

--- a/src/apis/auth/useGetUserInfo.ts
+++ b/src/apis/auth/useGetUserInfo.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { getLocalStorage } from "@/utils/localStorage";
 
 import auth from "./queryKey";
 
-const useGetUserInfo = (isInvalidUserId: boolean, token: string) => {
-  return useQuery(auth.userInfo(isInvalidUserId, token));
+const useGetUserInfo = () => {
+  const token = getLocalStorage("token", "");
+  return useQuery(auth.userInfo(token));
 };
 
 export default useGetUserInfo;

--- a/src/apis/auth/useGetUserInfo.ts
+++ b/src/apis/auth/useGetUserInfo.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { parseFullName } from "@/utils/parsingJson";
+
+import auth from "./queryKey";
+
+const useGetUserInfo = (isInvalidUserId: boolean, token: string) => {
+  const { data, isLoading } = useQuery(auth.userInfo(isInvalidUserId, token));
+  if (!data || isLoading) return;
+
+  const { _id: id, email, fullName } = data;
+  const { name, nickname } = parseFullName(fullName);
+  return { id, email, name, nickname, token, isLoggedIn: true };
+};
+
+export default useGetUserInfo;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-
-import App from "./App.tsx";
 import "./index.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+import App from "./App";
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## 📝 작업 내용

- ~스토어에 저장된 user 객체가 없는 경우(null) 로컬 스토리지에 저장된 token을 이용해 유저 인증 api를 조회하여 다시 저장하는 로직을 구현했습니다.~
    - 로컬 스토리지에 토큰이 있기 때문에 유저 정보는 api를 통해 불러올 수 밖에 없는 상황압니다. 어차피 유저 정보를 불러와야 하는데 스토어에까지 저장을 해야하는지에 대한 의문과 유저 정보를 어디서 불러와야 하는지에 대한 고민으로 우선 유저 정보를 불러오는 훅만 구현했습니다.!

- 새로고침 시 해당 라우트에서 유저 정보가 스토어에 있는지 확인하려면 App에서 접근을 해야하기 때문에 App에 코드를 작성했습니다.
    - 따라서 App에서 리액트 쿼리를 이용해 유저 인증 api를 조회해야 하기 때문에 `QueryClientProvider` 태그를 main으로 옮겼습니다.

## 💬 리뷰 요구사항

- 이 로직을 구현하는 것이 처음이라 여러 방법을 고민해보았는데, 최상위를 수정하는 방법 밖에 떠오르지 같아 최상위 컴포넌트들을 수정했습니다. 근데 최상위 만큼은 프로젝트 진행 단계에 수정하고 싶지 않았던지라 ,, 다른 좋은 방법이 있으면 그 방법에 맞게 수정해보겠습니다!!

- 스토어에 저장된 user 객체와 로컬 스토리지에 저장된 token 문자열에 따라 쿼리를 실행할 수 있도록 `enabled`에 넣었는데도 실행이 되는 것 같습니다..! [캐싱된게 없을 때는 pending 상태인 것](https://tanstack.com/query/latest/docs/react/guides/disabling-queries)으로 이해했는데, 제가 잘못 이해한 것인지 혹은 조건을 잘못 넣은 것인지 확인해주시면 감사하겠습니다.! 🥲

- ~zustand devtools를 이용해 테스트를 했는데 이 부분도 우선 커밋을 해놓았습니다! 만약 PR과 관계 없거나, 필요없는 기능이라고 생각한다면 커밋 취소하겠습니다. :)~ > 커밋 취소했습니다!

close #36
