### PR TITLE
[#61] Fix: 회원가입 시 로그인 모달 버벅임 버그 해결

### DIFF
--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -26,9 +26,9 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
   } = useRegister();
 
   const handleLoginClick = useCallback(() => {
-    toggleOpen(!open);
+    toggleOpen(false);
     openLoginModal(true);
-  }, [open, toggleOpen, openLoginModal]);
+  }, [toggleOpen, openLoginModal]);
 
   useEffect(() => {
     if (isRegisterSuccess) handleLoginClick();


### PR DESCRIPTION
## 📝 작업 내용

`useEffect`를 통해 회원가입 쿼리 실행 후 반환되는 성공 여부에 따라 `handleLoginClick` 함수를 실행하게 했는데 `handleLoginClick`이 계속 새롭게 할당되어 `useCallback`을 통해 최적화를 했습니다. `handleLoginClick`은 `open` 상태를 계속 토글하는 로직을 갖고 있습니다. 이 때문에 `useCallback`의 의존성 배열에 `open`이라는 상태가 들어가있어 토글이 되면 계속 감지하고, 새로 할당되어 무한루프가 발생했기 때문에 버벅임 현상이 발생한 것 입니다.

(만약 잘못 설명한 부분이 있다면 지적 부탁 드립니다!)

따라서 회원가입 모달에서 로그인 모달로 넘어가는 경우는 `회원가입 모달 닫기 + 로그인 모달 열기`이기 때문에 `open` 상태를 토글할 필요가 없다고 생각하여 고정값인 `false`로 상태를 변경해주었습니다.

아래는 테스트를 위해 작성한 코드 입니다.! 이슈에도 첨부했습니다 :D
계속 api를 실행하기엔 비용이 큰 것 같아 함수를 트리거할 새로운 상태를 만들어 테스트했습니다!

```ts
// given

const [isTrigger, setIsTrigger] = useState(false);

const handleLoginClick = useCallback(() => {
  console.log("handleLoginClick", open);
  toggleOpen(!open);
  openLoginModal(true);
}, [open, toggleOpen, openLoginModal]);

const handleLoginClick1 = useCallback(() => {
  console.log("handleLoginClick 1", open);
  toggleOpen(false);
  openLoginModal(true);
}, [toggleOpen, openLoginModal]);

const handleSubmit = () => setIsTrigger(true);

// when

useEffect(() => {
  if (isTrigger) handleLoginClick();
}, [isTrigger, handleLoginClick]);

useEffect(() => {
  if (isTrigger) handleLoginClick1();
}, [isTrigger, handleLoginClick1]);

// then

// 아래 스크린샷 첨부했습니다. (주석처리하며 번갈아 실행했습니다)
```

### 📷 스크린샷

![스크린샷 2024-01-04 오전 11 24 54](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/6a82b48a-c7db-4bfc-b2de-658b0b86c5c4)

`handleLoginClick`인 경우에는 `open` 값이 계속 토글되어 무한루프가 발생하고 있는 것을 확인할 수 있습니다.

## 💬 리뷰 요구사항

- 원인을 제대로 파악하여 올바르게 고쳤는지
- 설명을 정확하게 했는지

궁금합니다..,,


close #61
