### PR TITLE
[#63] Feat: 로그인 후 모달 닫기

### DIFF
--- a/src/apis/auth/useLogin.ts
+++ b/src/apis/auth/useLogin.ts
@@ -6,7 +6,11 @@ import { setLocalStorage } from "@/utils/localStorage";
 
 import { postLogin, LoginRequest, AuthResponse } from "./queryFn";
 
-const useLogin = () => {
+interface Props {
+  toggleOpen: (open: boolean) => void;
+}
+
+const useLogin = ({ toggleOpen }: Props) => {
   const { updateUser } = useUserStore();
 
   const parseUser = (data: AuthResponse) => {
@@ -32,6 +36,7 @@ const useLogin = () => {
       updateUser(user);
       setLocalStorage("token", user.token);
     },
+    onSettled: () => toggleOpen(false),
   });
 };
 

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
-  const { mutate: loginMutate } = useLogin();
+  const { mutate: loginMutate } = useLogin({ toggleOpen });
 
   const handleRegisterClick = () => {
     toggleOpen(!open);


### PR DESCRIPTION
## 📝 작업 내용

로그인 후 성공/실패 여부에 상관 없이 모달 닫는 기능을 구현했습니다.

## 💬 리뷰 요구사항

`useLogin` 훅에 `toggleOpen` 함수를 props로 넘겨줄지(현재 코드) 혹은 쿼리가 반환하는 `isSettled` 값을 사용할까 고민했습니다.
큰 상관은 없지만 `isSuccess`, `onSuccess`같은 것들을 어떤 상황에서 쓰는시지 조금 궁금해졌습니다,,

close #63
