### PR TITLE
[#65] Modify: 내가 쓴 글에서 커스텀훅으로 user정보 받아오도록 로직 변경

### DIFF
--- a/src/components/MyThreads/MyThreadBody.tsx
+++ b/src/components/MyThreads/MyThreadBody.tsx
@@ -1,21 +1,20 @@
-import useUserStore from "@/stores/user";
-
 import MyThreadItem from "./MyThreadItem";
 
 import useGetMyThread from "@/apis/mythreads/useMyThreadQuery";
+import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 
 const Date = ({ date }: { date?: string }) => {
   return <p className="text-m mt-40pxr py-1pxr font-bold">{date}</p>;
 };
 
+const DEFAULT_VALUE = "658f0f92c31af67084101253";
 //TODO: Comments는 API에서 GET으로 받아올 수 없는 문제 처리 논의 (2023.12.30)
 
 const MyThreadBody = () => {
-  const user = useUserStore((state) => state.user);
-  const id = user?.id;
-
+  const { data } = useGetUserInfo();
   //TODO: 현재는 비로그인 시에도 list목록이 보이게 id 직접 넣어줬지만, 비로그인시 동작 논의(2024.01.02)
-  const { myThreads, isPending } = useGetMyThread(id ? id : "658f0f92c31af67084101253");
+  const id = data ? data._id : DEFAULT_VALUE;
+  const { myThreads, isPending } = useGetMyThread(id);
 
   if (isPending || myThreads === undefined) {
     return <span>Loading...</span>;


### PR DESCRIPTION
## 📝 작업 내용

기존 store에서 user정보 받아오던 로직에서 새로고침 시 유저정보가 유지가 되지않던 이슈가 있어서
커스텀 훅으로 react query가 항상 로컬스토리지 토큰에서 유저 정보를 받아오도록 수정합니다.

close #65