### PR TITLE
[#72] Style: 프로필 편집 모달 UI 퍼블리싱

### DIFF
--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { DialogClose } from "@/components/ui/dialog";
 
 export interface FieldProps {
   name: string;
@@ -37,9 +38,16 @@ export interface SimpleFormProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSubmit: (values: any) => void;
   submitText: string;
+  cancelText?: string;
 }
 
-const SimpleBaseForm = ({ fields, validationSchema, submitText, onSubmit }: SimpleFormProps) => {
+const SimpleBaseForm = ({
+  fields,
+  validationSchema,
+  submitText,
+  cancelText,
+  onSubmit,
+}: SimpleFormProps) => {
   const defaultValues = fields.reduce((sum, { name, value }) => {
     // defaultValue를 무조건 지정해줘야 하므로 생성
     return {
@@ -82,7 +90,14 @@ const SimpleBaseForm = ({ fields, validationSchema, submitText, onSubmit }: Simp
             )}
           />
         ))}
-        <Button type="submit">{submitText}</Button>
+        <div className="flex items-center justify-center">
+          <Button type="submit">{submitText}</Button>
+          {cancelText && (
+            <DialogClose className="ml-2 rounded-md border bg-background px-4 py-2.5 text-sm font-medium">
+              {cancelText}
+            </DialogClose>
+          )}
+        </div>
       </form>
     </Form>
   );

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -1,6 +1,7 @@
 import * as z from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { PropsWithChildren } from "react";
 
 import {
   Form,
@@ -31,7 +32,7 @@ export interface FieldProps {
   value?: string;
 }
 
-export interface SimpleFormProps {
+export interface SimpleFormProps extends PropsWithChildren {
   fields: FieldProps[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validationSchema: z.ZodEffects<z.ZodObject<any>> | z.ZodObject<any>;
@@ -47,6 +48,7 @@ const SimpleBaseForm = ({
   submitText,
   cancelText,
   onSubmit,
+  children,
 }: SimpleFormProps) => {
   const defaultValues = fields.reduce((sum, { name, value }) => {
     // defaultValue를 무조건 지정해줘야 하므로 생성
@@ -65,6 +67,7 @@ const SimpleBaseForm = ({
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        {children}
         {fields.map(({ name, label, desc, ...props }) => (
           <FormField
             key={name}

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -18,7 +18,6 @@ export interface FieldProps {
   name: string;
   type: string;
   label: string;
-  defaultValue?: string;
   autoFocus?: boolean;
   desc?: string;
   placeholder?: string;
@@ -27,6 +26,7 @@ export interface FieldProps {
    * @see https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/
    */
   autoComplete?: "username" | "current-password" | "new-password" | "nickname" | "off";
+  value?: string;
 }
 
 export interface SimpleFormProps {
@@ -39,11 +39,11 @@ export interface SimpleFormProps {
 }
 
 const SimpleBaseForm = ({ fields, validationSchema, submitText, onSubmit }: SimpleFormProps) => {
-  const defaultValues = fields.reduce((sum, { name, defaultValue }) => {
+  const defaultValues = fields.reduce((sum, { name, value }) => {
     // defaultValue를 무조건 지정해줘야 하므로 생성
     return {
       ...sum,
-      [name]: defaultValue ?? "",
+      [name]: value ?? "",
     };
   }, {});
 

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -26,6 +26,7 @@ export interface FieldProps {
    * @see https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/
    */
   autoComplete?: "username" | "current-password" | "new-password" | "nickname" | "off";
+  readOnly?: boolean;
   value?: string;
 }
 

--- a/src/components/Layout/Modals/Base/modal.tsx
+++ b/src/components/Layout/Modals/Base/modal.tsx
@@ -18,7 +18,7 @@ interface Props extends PropsWithChildren {
 const SimpleBaseModal = ({ dialogOptions = {}, title, header, children }: Props) => {
   return (
     <Dialog {...dialogOptions}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="max-h-[800px] overflow-scroll sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{header}</DialogDescription>

--- a/src/components/Layout/Modals/Base/modal.tsx
+++ b/src/components/Layout/Modals/Base/modal.tsx
@@ -12,7 +12,7 @@ import {
 interface Props extends PropsWithChildren {
   dialogOptions?: DialogProps;
   title: string;
-  header: ReactNode;
+  header?: ReactNode;
 }
 
 const SimpleBaseModal = ({ dialogOptions = {}, title, header, children }: Props) => {

--- a/src/components/Layout/Modals/Setting/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Setting/ImageUploadForm.tsx
@@ -1,0 +1,25 @@
+import { Image, ImageOff } from "lucide-react";
+import { useRef } from "react";
+
+import { Button } from "@/components/ui/button";
+
+const ImageUploadForm = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="flex flex-col items-center">
+      <input ref={inputRef} type="image" className="hidden" />
+      <img className="h-40 w-40 rounded-sm bg-gray-200" />
+      <Button className="my-2">
+        <Image className="mr-2" />
+        사진 업로드
+      </Button>
+      <Button variant="outline">
+        <ImageOff className="mr-2" />
+        사진 제거
+      </Button>
+    </div>
+  );
+};
+
+export default ImageUploadForm;

--- a/src/components/Layout/Modals/Setting/config.ts
+++ b/src/components/Layout/Modals/Setting/config.ts
@@ -28,12 +28,6 @@ export const SETTING_FIELDS: FieldProps[] = [
     value: "프롱이",
   },
   {
-    name: "passwordCurrent",
-    type: "password",
-    label: "기존 비밀번호",
-    autoComplete: "current-password",
-  },
-  {
     name: "password",
     type: "password",
     label: "새 비밀번호",

--- a/src/components/Layout/Modals/Setting/config.ts
+++ b/src/components/Layout/Modals/Setting/config.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { FieldProps } from "../Base/form";
+
+export const SETTING_FIELDS: FieldProps[] = [
+  {
+    name: "name",
+    type: "text",
+    label: "이름",
+    autoFocus: true,
+    autoComplete: "off",
+    readOnly: true,
+    value: "프롱이",
+  },
+  {
+    name: "email",
+    type: "email",
+    label: "이메일",
+    autoComplete: "username",
+    readOnly: true,
+    value: "email@naver.com",
+  },
+  {
+    name: "nickname",
+    type: "text",
+    label: "닉네임",
+    autoComplete: "nickname",
+    value: "프롱이",
+  },
+  {
+    name: "passwordCurrent",
+    type: "password",
+    label: "기존 비밀번호",
+    autoComplete: "current-password",
+  },
+  {
+    name: "password",
+    type: "password",
+    label: "새 비밀번호",
+    autoComplete: "new-password",
+  },
+  {
+    name: "passwordConfirm",
+    type: "password",
+    label: "새 비밀번호 확인",
+    autoComplete: "new-password",
+  },
+];
+
+export const SETTING_FIELDS_SCHEMA = z
+  .object({
+    nickname: z.string().trim().min(1, {
+      message: "닉네임을 입력해주세요",
+    }),
+    password: z.string().min(8, {
+      message: "비밀번호는 8글자 이상이어야 합니다",
+    }),
+    passwordConfirm: z.string(),
+  })
+  .refine(({ password, passwordConfirm }) => password === passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  });

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import SimpleBaseForm from "../Base/form";
+import SimpleBaseModal from "../Base/modal";
+
+import { SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config";
+
+interface Props {
+  open: boolean;
+  toggleOpen: (open: boolean) => void;
+}
+
+const SettingModal = ({ open, toggleOpen }: Props) => {
+  const handleSubmit = (settingInfo: z.infer<typeof SETTING_FIELDS_SCHEMA>) => {
+    console.log(settingInfo);
+  };
+
+  return (
+    <SimpleBaseModal
+      dialogOptions={{
+        open,
+        onOpenChange: toggleOpen,
+      }}
+      title="내 프로필 편집"
+    >
+      <SimpleBaseForm
+        fields={SETTING_FIELDS}
+        validationSchema={SETTING_FIELDS_SCHEMA}
+        onSubmit={handleSubmit}
+        submitText="저장"
+        cancelText="취소"
+      >
+      </SimpleBaseForm>
+    </SimpleBaseModal>
+  );
+};
+
+export default SettingModal;

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -4,6 +4,7 @@ import SimpleBaseForm from "../Base/form";
 import SimpleBaseModal from "../Base/modal";
 
 import { SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config";
+import ImageUploadForm from "./ImageUploadForm";
 
 interface Props {
   open: boolean;
@@ -30,6 +31,7 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
         submitText="저장"
         cancelText="취소"
       >
+        <ImageUploadForm />
       </SimpleBaseForm>
     </SimpleBaseModal>
   );

--- a/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
+++ b/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
@@ -19,6 +19,11 @@ import { IconCSS, IconDescriptionCSS } from "./styles";
  */
 export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
   const [settingModalOpen, setSettingModalOpen] = useState(false);
+
+  const settingModalOpenHandler = () => {
+    setSettingModalOpen(true);
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
@@ -35,7 +40,10 @@ export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
             <span className={IconDescriptionCSS}>다크</span>
           </div>
         </DropdownMenuItem>
-        <DropdownMenuItem className="cursor-pointer text-lg hover:text-2xl">
+        <DropdownMenuItem
+          className="cursor-pointer text-lg hover:text-2xl"
+          onClick={settingModalOpenHandler}
+        >
           <div className="flex items-center gap-2 p-2">
             <SettingsIcon className={IconCSS} />
             <span className={IconDescriptionCSS}>시스템</span>

--- a/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
+++ b/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
@@ -1,5 +1,5 @@
 import { MoonIcon, SettingsIcon, SunIcon } from "lucide-react";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useState } from "react";
 
 import {
   DropdownMenu,
@@ -8,8 +8,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import { IconCSS, IconDescriptionCSS } from "./styles";
+import SettingModal from "../Modals/Setting";
 
+import { IconCSS, IconDescriptionCSS } from "./styles";
 // TODO: [2023-12-29] 전역 상태 혹은 반영구 저장소와 연동해야 하므로 해당 Custom Hook과 연동하기
 /**
  * 테마를 설정하는 드롭다운
@@ -17,6 +18,7 @@ import { IconCSS, IconDescriptionCSS } from "./styles";
  * children은 클릭 시 드롭다운을 여는 트리거 영역이 됨.
  */
 export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
+  const [settingModalOpen, setSettingModalOpen] = useState(false);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
@@ -40,6 +42,7 @@ export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
           </div>
         </DropdownMenuItem>
       </DropdownMenuContent>
+      <SettingModal open={settingModalOpen} toggleOpen={setSettingModalOpen} />
     </DropdownMenu>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용

- 이전 성빈님이 작업하신 모달과 비슷한 코드로 작성했습니다.
- 프로필 편집 모달 인풋에는 수정 불가능한 것들이 있기 때문에 수정이 불가능하면 default value를 지정하려고 했습니다. 그러나 만드신 공통 input에는 value와 handler 함수가 항상 들어가다보니 value와 default value 가 같이 들어가면 경고가 떠 value로 통일하고 readonly 속성도 함께 사용했습니다.! 만약 잘못된 해결 방법이라면 리뷰 달아주세요 :)
- 프로필 편집 모달이 길어져 최대 높이와 스크롤을 추가했습니다.

### 추후 작업 내용

- 유효성 검사는 아직 세세하게 다루지 않았습니다.
- 모달을 최상단에 두어 zustand와 관리하는 것은 나중에 한번에 리팩토링 하겠습니다!

### 📷 스크린샷

<img width="975" alt="스크린샷 2024-01-08 오전 9 26 06" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/5f8d665d-2a5e-4572-acec-98953acc1af8">

## 💬 리뷰 요구사항

- 사진 첨부하는 부분은 children props으로 받아오게 했는데 좋은 방법인지 모르겠네요!
- 코드 전반적으로 가독성이 좋은지, 잘 짜여진 코드인지 궁금합니다.

close #72 
