### PR TITLE
Fix: comment 알림의 대상, 멘션 타입 수정

### DIFF
--- a/src/components/Demo/ExEditorTextArea.tsx
+++ b/src/components/Demo/ExEditorTextArea.tsx
@@ -12,7 +12,11 @@ const ExEditorTextArea = () => {
     postId,
   };
 
-  const commentProps = { channelName: "칭찬", postId }; // channelName은 Post.channel.name 값 전달
+  const commentProps = {
+    channelName: "무능 게시판",
+    postId: "659b4ae942677b4eb8c08e0f",
+    postAuthorId: "65955240a178ac62e4022f0d",
+  }; // channelName은 Post.channel.name 값 전달, postId는 Post.author._id 값 전달, postAuthorId는 Post.author._id 값 전달
 
   return (
     <div className="flex h-screen w-full flex-grow items-center justify-center">

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -17,6 +17,7 @@ interface PatchThreadProps {
 interface CommentProps {
   channelName: string;
   postId: string;
+  postAuthorId: string;
 }
 
 export type EditorProps = CreateThreadProps | PatchThreadProps | CommentProps;
@@ -59,6 +60,7 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionList }: Props) =>
     nickname,
     postId: isCommentProps(editorProps) ? editorProps.postId : "",
     channelName: isCommentProps(editorProps) ? editorProps.channelName : "",
+    postAuthorId: isCommentProps(editorProps) ? editorProps.postAuthorId : "",
     mentionList,
   });
 

--- a/src/hooks/api/useMentionNotification.ts
+++ b/src/hooks/api/useMentionNotification.ts
@@ -26,7 +26,7 @@ const useMentionNotification = ({ mentionList }: Props) => {
       const mentionResponse = await mentionMutate(mentionRequest);
 
       const notificationRequest = {
-        notificationType: "MENTION" as NotificationTypes,
+        notificationType: "MESSAGE" as NotificationTypes,
         notificationTypeId: mentionResponse._id,
         userId: mentionResponse.sender._id,
         postId,

--- a/src/hooks/api/useUploadComment.ts
+++ b/src/hooks/api/useUploadComment.ts
@@ -11,9 +11,10 @@ interface Props {
   postId: string;
   channelName: string;
   mentionList?: UserDBProps[];
+  postAuthorId: string;
 }
 
-const useUploadComment = ({ nickname, postId, channelName, mentionList }: Props) => {
+const useUploadComment = ({ nickname, postId, channelName, mentionList, postAuthorId }: Props) => {
   const { mutateAsync: commentMutate } = usePostComment();
   const { mutate: notificationMutate } = usePostNotification();
   const { mentionNotification } = useMentionNotification({ mentionList });
@@ -31,7 +32,7 @@ const useUploadComment = ({ nickname, postId, channelName, mentionList }: Props)
     const notificationRequest = {
       notificationType: "COMMENT" as NotificationTypes,
       notificationTypeId: commentResponse._id,
-      userId: commentResponse.author._id,
+      userId: postAuthorId,
       postId,
     };
 


### PR DESCRIPTION
## 📝 작업 내용

멘션시와 알림 시 오류가 있어서 수정했습니다. 
1. notificationType : MENTION => MESSAGE
2. comment 알림 대상 => 자신으로 되어있어서 post 작성자로 변경
