### PR TITLE
[#33] Feat: 스레드 자세히 보기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import MyThreadsPage from "./pages/MyThreads";
 import MyNotificationsPage from "./pages/MyNotifications";
 import NotFoundPage from "./pages/NotFound";
 import Layout from "./components/Layout";
+import ExThreadDetailView from "./components/Demo/ExThreadDetailView";
 
 import ExEditorTextArea from "@/components/Demo/ExEditorTextArea.tsx";
 
@@ -18,6 +19,7 @@ const App = () => (
         <Route path="my-notifications" element={<MyNotificationsPage />} />
         {/*TODO : [24/1/8] 에디터 데모 다음 머지 시 삭제 (이번에는 PR 없이 머지하기로 해서 남겨두겠습니다) */}
         <Route path="demo" element={<ExEditorTextArea />} />
+        <Route path="detail" element={<ExThreadDetailView />} />
       </Route>
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/src/components/Demo/ExThreadDetailView.tsx
+++ b/src/components/Demo/ExThreadDetailView.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+import ThreadDetailView from "../common/thread/ThreadDetailView";
+
+import useGetThread from "@/apis/thread/useGetThread";
+
+const DEMO_POST_ID = "65982e1bf226073f4c8a0da2";
+
+/**
+ * Thread Detail View를 사용하는 페이지의 예시 코드.
+ *
+ * thread, onClose를 넘겨줘야 한다.
+ */
+const ExThreadDetailView = () => {
+  const [isOpen, setOpen] = useState(true);
+  const { thread, isLoading } = useGetThread(DEMO_POST_ID);
+  const hideView = !isOpen || !thread || isLoading;
+
+  const handleClose = () => {
+    setOpen(!isOpen);
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <button onClick={handleClose}>페이지 다시 열기</button>
+      <div className="w-600pxr">
+        {!hideView && <ThreadDetailView thread={thread!} onClose={handleClose} />}
+      </div>
+    </div>
+  );
+};
+
+export default ExThreadDetailView;

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -1,0 +1,46 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+import { formatDate } from "@/utils/formatDate";
+import { parseTitle } from "@/utils/parsingJson";
+
+import { Comment } from "@/types/thread";
+
+interface Props {
+  comment: Comment;
+}
+
+/**
+ * 일관성 유지를 위해 ThreadListItem의 기능을 단순히 제거한 버전으로 스타일의 변경은 없는 코드이다.
+ * 컴포넌트 통합 혹은 중복 코드 제거 등의 책임은 ThreadListItem 작성자에게 있다.
+ */
+const CommentListItem = ({ comment }: Props) => {
+  const { content, nickname } = parseTitle(comment.comment);
+  return (
+    <li className="relative cursor-pointer px-2.5 py-5 hover:bg-gray-100">
+      <div className="flex items-center">
+        <Avatar className="mr-3">
+          <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
+          <AvatarFallback>{nickname?.charAt(0)}</AvatarFallback>
+        </Avatar>
+        <div className="flex-grow min-w-0">
+          <div className="flex justify-between">
+            <span tabIndex={0} className="text-lg font-semibold">
+              {nickname || "익명의 프롱이"}
+            </span>
+            <span tabIndex={0} className="text-gray-400">
+              {formatDate(comment.createdAt)}
+            </span>
+          </div>
+          <div
+            tabIndex={0}
+            className="overflow-hidden text-gray-500 truncate text-ellipsis pr-50pxr"
+          >
+            {content}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default CommentListItem;

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -19,7 +19,7 @@ const channelMap = {
 
 const ThreadDetailView = ({ thread, onClose }: Props) => {
   return (
-    <div className="flex flex-col h-screen px-6 py-4 overflow-auto list-none min-w-500pxr">
+    <div className="flex flex-col h-screen py-4 overflow-auto list-none min-w-500pxr">
       <div className="flex items-center justify-between p-2">
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-bold text-gray-700">스레드</h2>

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -1,0 +1,48 @@
+import { XIcon } from "lucide-react";
+
+import { Thread } from "@/types/thread";
+
+import ThreadListItem from "./ThreadListItem";
+import CommentListItem from "./CommentListItem";
+
+interface Props {
+  thread: Thread;
+  onClose: () => void;
+}
+
+// 중복 코드. 출처: src/components/MyThreads/MyThreadsItem.tsx
+const channelMap = {
+  cheering: "응원",
+  compliment: "칭찬",
+  incompetent: "무능",
+};
+
+const ThreadDetailView = ({ thread, onClose }: Props) => {
+  return (
+    <div className="flex flex-col h-screen px-6 py-4 overflow-auto list-none min-w-500pxr">
+      <div className="flex items-center justify-between p-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-2xl font-bold text-gray-700">스레드</h2>
+          <p className="text-sm text-muted-foreground">#{channelMap[thread.channel.name]}게시판</p>
+        </div>
+        <button onClick={onClose}>
+          <XIcon className="text-gray-500" />
+        </button>
+      </div>
+      <ThreadListItem {...thread} id={thread._id} channelId={thread.channel._id} />
+      <div className="flex items-center gap-2 mx-2">
+        <span className="text-gray-500">{thread.comments.length}개의 댓글</span>
+        <hr className="flex-1" />
+      </div>
+      <div>
+        <ol className="flex flex-col gap-4">
+          {thread.comments.map((comment) => (
+            <CommentListItem key={comment._id} comment={comment} />
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+};
+
+export default ThreadDetailView;


### PR DESCRIPTION
resolves #33 

Visit: https://fedc-5-dev-namu-eunsu-git-33-featurethread-de-70c95b-devnamu-v1.vercel.app/detail

## 📝 작업 내용

- [x] 스레드 객체를 받아 렌더링한다.
- [x] 닫을 수 있다.

### 📷 스크린샷 (선택)

![image](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/28754907/5318f6cc-7348-4087-b8d4-dfa273c9918b)
