### PR TITLE
[#81] Feat: 프로필 변경 로직 구현

### DIFF
--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -25,3 +25,10 @@ export const postRegister = (registerInfo: RegisterRequest) =>
 export const postLogout = () => api.post<string>({ url: "/logout" });
 
 export const getUserInfo = () => api.get<User>({ url: "/auth-user" });
+
+export const putUserInfo = (userInfo: string) =>
+  api.put<User>({ url: "/settings/update-user", data: { fullName: userInfo, username: "" } });
+
+export const putUserPassword = (password: string) =>
+  api.put<string>({ url: "/settings/update-password", data: { password } });
+

--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -32,3 +32,5 @@ export const putUserInfo = (userInfo: string) =>
 export const putUserPassword = (password: string) =>
   api.put<string>({ url: "/settings/update-password", data: { password } });
 
+export const postUserProfileImage = (image: string) =>
+  api.post<User>({ url: "/users/upload-photo", data: { isCover: false, image } });

--- a/src/apis/auth/usePutProfile.ts
+++ b/src/apis/auth/usePutProfile.ts
@@ -1,10 +1,21 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { getLocalStorage } from "@/utils/localStorage";
 
 import { putUserInfo, putUserPassword } from "./queryFn";
+import auth from "./queryKey";
 
 const usePutProfile = () => {
+  const queryClient = useQueryClient();
+  const token = getLocalStorage("token", "");
+
   const { data: userResponse, mutate: profileChangeMutate } = useMutation({
     mutationFn: (userInfo: string) => putUserInfo(userInfo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: auth.userInfo(token).queryKey,
+      });
+    },
   });
 
   const { data: passwordResponse, mutate: passwordChangeMutate } = useMutation({

--- a/src/apis/auth/usePutProfile.ts
+++ b/src/apis/auth/usePutProfile.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { getLocalStorage } from "@/utils/localStorage";
 
-import { putUserInfo, putUserPassword } from "./queryFn";
+import { postUserProfileImage, putUserInfo, putUserPassword } from "./queryFn";
 import auth from "./queryKey";
 
 const usePutProfile = () => {
@@ -21,7 +21,19 @@ const usePutProfile = () => {
   const { data: passwordResponse, mutate: updatePassword } = useMutation({
     mutationFn: (password: string) => putUserPassword(password),
   });
-  return { updateUserName, updatePassword, userResponse, passwordResponse };
+
+  const { data: imageResponse, mutate: updateProfileImage } = useMutation({
+    mutationFn: (image: string) => postUserProfileImage(image),
+  });
+
+  return {
+    updateUserName,
+    updatePassword,
+    updateProfileImage,
+    imageResponse,
+    userResponse,
+    passwordResponse,
+  };
 };
 
 export default usePutProfile;

--- a/src/apis/auth/usePutProfile.ts
+++ b/src/apis/auth/usePutProfile.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { putUserInfo, putUserPassword } from "./queryFn";
+
+const usePutProfile = () => {
+  const { data: userResponse, mutate: profileChangeMutate } = useMutation({
+    mutationFn: (userInfo: string) => putUserInfo(userInfo),
+  });
+
+  const { data: passwordResponse, mutate: passwordChangeMutate } = useMutation({
+    mutationFn: (password: string) => putUserPassword(password),
+  });
+  return { profileChangeMutate, passwordChangeMutate, userResponse, passwordResponse };
+};
+
+export default usePutProfile;

--- a/src/apis/auth/usePutProfile.ts
+++ b/src/apis/auth/usePutProfile.ts
@@ -9,7 +9,7 @@ const usePutProfile = () => {
   const queryClient = useQueryClient();
   const token = getLocalStorage("token", "");
 
-  const { data: userResponse, mutate: profileChangeMutate } = useMutation({
+  const { data: userResponse, mutate: updateUserName } = useMutation({
     mutationFn: (userInfo: string) => putUserInfo(userInfo),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -18,10 +18,10 @@ const usePutProfile = () => {
     },
   });
 
-  const { data: passwordResponse, mutate: passwordChangeMutate } = useMutation({
+  const { data: passwordResponse, mutate: updatePassword } = useMutation({
     mutationFn: (password: string) => putUserPassword(password),
   });
-  return { profileChangeMutate, passwordChangeMutate, userResponse, passwordResponse };
+  return { updateUserName, updatePassword, userResponse, passwordResponse };
 };
 
 export default usePutProfile;

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -32,6 +32,7 @@ export interface FieldProps {
   value?: string;
 }
 
+// TODO: zod의 any 타입 제거 및 재귀 타입 어떻게 생성할지 고민해보기 (2024-01-08)
 export interface SimpleFormProps extends PropsWithChildren {
   fields: FieldProps[];
   validationSchema: // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/Layout/Modals/Base/form.tsx
+++ b/src/components/Layout/Modals/Base/form.tsx
@@ -34,8 +34,12 @@ export interface FieldProps {
 
 export interface SimpleFormProps extends PropsWithChildren {
   fields: FieldProps[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  validationSchema: z.ZodEffects<z.ZodObject<any>> | z.ZodObject<any>;
+  validationSchema: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | z.ZodEffects<z.ZodEffects<z.ZodObject<any>>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | z.ZodEffects<z.ZodObject<any>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | z.ZodObject<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSubmit: (values: any) => void;
   submitText: string;

--- a/src/components/Layout/Modals/Base/modal.tsx
+++ b/src/components/Layout/Modals/Base/modal.tsx
@@ -20,6 +20,7 @@ const SimpleBaseModal = ({ dialogOptions = {}, title, header, children }: Props)
     <Dialog {...dialogOptions}>
       <DialogContent
         onInteractOutside={(e) => e.preventDefault()}
+        onOpenAutoFocus={(e) => e.preventDefault()}
         className="max-h-[800px] overflow-scroll sm:max-w-[425px]"
       >
         <DialogHeader>

--- a/src/components/Layout/Modals/Base/modal.tsx
+++ b/src/components/Layout/Modals/Base/modal.tsx
@@ -18,7 +18,10 @@ interface Props extends PropsWithChildren {
 const SimpleBaseModal = ({ dialogOptions = {}, title, header, children }: Props) => {
   return (
     <Dialog {...dialogOptions}>
-      <DialogContent className="max-h-[800px] overflow-scroll sm:max-w-[425px]">
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        className="max-h-[800px] overflow-scroll sm:max-w-[425px]"
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{header}</DialogDescription>

--- a/src/components/Layout/Modals/Setting/config.ts
+++ b/src/components/Layout/Modals/Setting/config.ts
@@ -43,15 +43,23 @@ export const SETTING_FIELDS: FieldProps[] = [
 
 export const SETTING_FIELDS_SCHEMA = z
   .object({
+    name: z.string(),
     nickname: z.string().trim().min(1, {
       message: "닉네임을 입력해주세요",
     }),
-    password: z.string().min(8, {
-      message: "비밀번호는 8글자 이상이어야 합니다",
-    }),
+    password: z.string(),
     passwordConfirm: z.string(),
   })
-  .refine(({ password, passwordConfirm }) => password === passwordConfirm, {
-    message: "비밀번호가 일치하지 않습니다",
-    path: ["passwordConfirm"],
+  .refine(
+    ({ password, passwordConfirm }) =>
+      (password.length && password === passwordConfirm) ||
+      (!password.length && !passwordConfirm.length),
+    {
+      message: "비밀번호가 일치하지 않습니다",
+      path: ["passwordConfirm"],
+    },
+  )
+  .refine(({ password }) => password.length >= 8 || !password.length, {
+    message: "비밀번호는 8글자 이상이어야 합니다",
+    path: ["password"],
   });

--- a/src/components/Layout/Modals/Setting/config.ts
+++ b/src/components/Layout/Modals/Setting/config.ts
@@ -2,44 +2,52 @@ import { z } from "zod";
 
 import { FieldProps } from "../Base/form";
 
-export const SETTING_FIELDS: FieldProps[] = [
-  {
-    name: "name",
-    type: "text",
-    label: "이름",
-    autoFocus: true,
-    autoComplete: "off",
-    readOnly: true,
-    value: "프롱이",
-  },
-  {
-    name: "email",
-    type: "email",
-    label: "이메일",
-    autoComplete: "username",
-    readOnly: true,
-    value: "email@naver.com",
-  },
-  {
-    name: "nickname",
-    type: "text",
-    label: "닉네임",
-    autoComplete: "nickname",
-    value: "프롱이",
-  },
-  {
-    name: "password",
-    type: "password",
-    label: "새 비밀번호",
-    autoComplete: "new-password",
-  },
-  {
-    name: "passwordConfirm",
-    type: "password",
-    label: "새 비밀번호 확인",
-    autoComplete: "new-password",
-  },
-];
+export interface UserInfo {
+  name: string;
+  email: string;
+  nickname: string;
+}
+
+export const SETTING_FIELDS: FieldProps[] = [];
+
+export const makeFormFields = ({ name, email, nickname }: UserInfo) => {
+  const result: FieldProps[] = [
+    {
+      name: "name",
+      type: "text",
+      label: "이름",
+      readOnly: true,
+      value: name,
+    },
+    {
+      name: "email",
+      type: "email",
+      label: "이메일",
+      readOnly: true,
+      value: email,
+    },
+    {
+      name: "nickname",
+      type: "text",
+      label: "닉네임",
+      autoComplete: "nickname",
+      value: nickname,
+    },
+    {
+      name: "password",
+      type: "password",
+      label: "새 비밀번호",
+      autoComplete: "new-password",
+    },
+    {
+      name: "passwordConfirm",
+      type: "password",
+      label: "새 비밀번호 확인",
+      autoComplete: "new-password",
+    },
+  ];
+  SETTING_FIELDS.splice(0, SETTING_FIELDS.length, ...result);
+};
 
 export const SETTING_FIELDS_SCHEMA = z
   .object({

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -30,6 +30,7 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
     if (settingInfo.password) {
       passwordChangeMutate(settingInfo.password);
     }
+    // TODO: 에러 모달 처리 (2024-01-09)
     toggleOpen(false);
   };
 

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -25,7 +25,8 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
       const fullName = { name: settingInfo.name, nickname: settingInfo.nickname };
       const userInfo = JSON.stringify(fullName);
       updateUserName(userInfo);
-    }
+      // TODO: 닉네임이 같은 경우 안내 처리 (2024-01-10)
+    } else alert("닉네임이 이전 닉네임과 동일합니다.");
     if (settingInfo.password) {
       updatePassword(settingInfo.password);
     }

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -27,7 +27,9 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
       const userInfo = JSON.stringify(fullName);
       profileChangeMutate(userInfo);
     }
+    if (settingInfo.password) {
       passwordChangeMutate(settingInfo.password);
+    }
   };
 
   return (

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -47,7 +47,7 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
         onSubmit={handleSubmit}
         submitText="저장"
         cancelText="취소"
-      ></SimpleBaseForm>
+      />
     </SimpleBaseModal>
   );
 };

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -30,6 +30,7 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
     if (settingInfo.password) {
       passwordChangeMutate(settingInfo.password);
     }
+    toggleOpen(false);
   };
 
   return (

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -3,8 +3,10 @@ import { z } from "zod";
 import SimpleBaseForm from "../Base/form";
 import SimpleBaseModal from "../Base/modal";
 
-import { SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config";
+import { makeFormFields, SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config";
 import ImageUploadForm from "./ImageUploadForm";
+
+import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 
 interface Props {
   open: boolean;
@@ -12,6 +14,9 @@ interface Props {
 }
 
 const SettingModal = ({ open, toggleOpen }: Props) => {
+  const { user, isPending } = useGetUserInfo();
+
+  if (open && !isPending && user) makeFormFields(user);
   const handleSubmit = (settingInfo: z.infer<typeof SETTING_FIELDS_SCHEMA>) => {
     console.log(settingInfo);
   };

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -19,11 +19,14 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
   const { profileChangeMutate, passwordChangeMutate } = usePutProfile();
 
   if (open && !isPending && user) makeFormFields(user);
+
   const handleSubmit = (settingInfo: z.infer<typeof SETTING_FIELDS_SCHEMA>) => {
-    console.log(settingInfo);
+    const oldNickname = user?.nickname;
+    if (oldNickname !== settingInfo.nickname) {
       const fullName = { name: settingInfo.name, nickname: settingInfo.nickname };
       const userInfo = JSON.stringify(fullName);
       profileChangeMutate(userInfo);
+    }
       passwordChangeMutate(settingInfo.password);
   };
 

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -7,6 +7,7 @@ import { makeFormFields, SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config"
 import ImageUploadForm from "./ImageUploadForm";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
+import usePutProfile from "@/apis/auth/usePutProfile";
 
 interface Props {
   open: boolean;
@@ -15,10 +16,15 @@ interface Props {
 
 const SettingModal = ({ open, toggleOpen }: Props) => {
   const { user, isPending } = useGetUserInfo();
+  const { profileChangeMutate, passwordChangeMutate } = usePutProfile();
 
   if (open && !isPending && user) makeFormFields(user);
   const handleSubmit = (settingInfo: z.infer<typeof SETTING_FIELDS_SCHEMA>) => {
     console.log(settingInfo);
+      const fullName = { name: settingInfo.name, nickname: settingInfo.nickname };
+      const userInfo = JSON.stringify(fullName);
+      profileChangeMutate(userInfo);
+      passwordChangeMutate(settingInfo.password);
   };
 
   return (

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const SettingModal = ({ open, toggleOpen }: Props) => {
   const { user, isPending } = useGetUserInfo();
-  const { profileChangeMutate, passwordChangeMutate } = usePutProfile();
+  const { updateUserName, updatePassword } = usePutProfile();
 
   if (open && !isPending && user) makeFormFields(user);
 
@@ -25,10 +25,10 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
     if (oldNickname !== settingInfo.nickname) {
       const fullName = { name: settingInfo.name, nickname: settingInfo.nickname };
       const userInfo = JSON.stringify(fullName);
-      profileChangeMutate(userInfo);
+      updateUserName(userInfo);
     }
     if (settingInfo.password) {
-      passwordChangeMutate(settingInfo.password);
+      updatePassword(settingInfo.password);
     }
     // TODO: 에러 모달 처리 (2024-01-09)
     toggleOpen(false);

--- a/src/components/Layout/Modals/Setting/index.tsx
+++ b/src/components/Layout/Modals/Setting/index.tsx
@@ -4,7 +4,6 @@ import SimpleBaseForm from "../Base/form";
 import SimpleBaseModal from "../Base/modal";
 
 import { makeFormFields, SETTING_FIELDS, SETTING_FIELDS_SCHEMA } from "./config";
-import ImageUploadForm from "./ImageUploadForm";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 import usePutProfile from "@/apis/auth/usePutProfile";
@@ -48,9 +47,7 @@ const SettingModal = ({ open, toggleOpen }: Props) => {
         onSubmit={handleSubmit}
         submitText="저장"
         cancelText="취소"
-      >
-        <ImageUploadForm />
-      </SimpleBaseForm>
+      ></SimpleBaseForm>
     </SimpleBaseModal>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용

~사진 업로드 구현이 되지 않았지만 시간 상 맞지 않는다면 이후로 넘어가도 좋다고 하셔서 draft로 올렸습니다.!~
~오늘 내로 어려울 것 같으면 사진 첨부 관련 부분 커밋은 삭제 후 draft 해제하겠습니다.~
~프로필 사진 로직 코드가 추가되어도 작업 완료한 부분 코드는 수정하지 않을 것 같아 코드를 읽으시는데 상관 없어서 draft로 미리 올렸습니다.~

테스트는 로그인 이후 사이드바에서 시스템 열면 가능합니다! :D
프로필 사진 변경 로직은 api 훅에 추가해두었지만 모달 쪽에서 구현이 되지 않아 이미지 업로드 컴포넌트만 view에서 삭제해두었습니다 :D

- 유저가 프로필 변경하기 위해 모달을 열 때 유저 정보(이름, 이메일, 닉네임) 불러와 인풋에 채워넣기
- 인풋 폼 유효성 검사
    - 닉네임 글자 수가 1개 이상이어야지 허용
    - 비밀번호는 8자 이상 입력해야 하며 입력 안한 경우에는 유효성 검사를 하지 않음
    - 비밀번호와 비밀번호 확인 인풋에 같은 값이 들어갔는지 검사, 둘 다 0글자 입력했을 때는 검사 안함
- 프로필 닉네임 변경 api 연결
    - 예전 닉네임과 같은 경우에는 api 호출하지 않음
- 비밀번호 변경 api 연결
    - 비밀번호 내용이 있는 경우에만 호출

## 💬 리뷰 요구사항

- 유효성 검사 부분에서 닉네임이 "프롱이"로 되어있을 시에는 회원가입 할 때 닉네임을 입력하지 않은 것이므로 닉네임을 필수로 변경하게끔 로직을 수정해야할까요?
- 놓친 유효성 검사가 있는지 궁금합니다.
- 그 외 편하게 리뷰 주시면 감사하겠습니다 :D

close #81 
