### PR TITLE
[#92] Feat: 로그인 여부에 따른 사이드바 아이콘 분기 처리

### DIFF
--- a/src/apis/auth/usePostLogout.ts
+++ b/src/apis/auth/usePostLogout.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { getLocalStorage, removeLocalStorage } from "@/utils/localStorage";
 
@@ -8,12 +9,15 @@ import auth from "./queryKey";
 const usePostLogout = () => {
   const queryClient = useQueryClient();
   const token = getLocalStorage("token", "");
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
 
   return useMutation({
     mutationFn: postLogout,
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: auth.userInfo(token).queryKey });
       removeLocalStorage("token");
+      if (pathname !== "/") navigate("/");
     },
   });
 };

--- a/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
+++ b/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
@@ -1,5 +1,5 @@
-import { MoonIcon, SettingsIcon, SunIcon } from "lucide-react";
-import { PropsWithChildren, useState } from "react";
+import { MoonIcon, SunIcon } from "lucide-react";
+import { PropsWithChildren } from "react";
 
 import {
   DropdownMenu,
@@ -7,8 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-
-import SettingModal from "../Modals/Setting";
 
 import { IconCSS, IconDescriptionCSS } from "./styles";
 // TODO: [2023-12-29] 전역 상태 혹은 반영구 저장소와 연동해야 하므로 해당 Custom Hook과 연동하기
@@ -18,12 +16,6 @@ import { IconCSS, IconDescriptionCSS } from "./styles";
  * children은 클릭 시 드롭다운을 여는 트리거 영역이 됨.
  */
 export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
-  const [settingModalOpen, setSettingModalOpen] = useState(false);
-
-  const settingModalOpenHandler = () => {
-    setSettingModalOpen(true);
-  };
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
@@ -40,17 +32,7 @@ export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
             <span className={IconDescriptionCSS}>다크</span>
           </div>
         </DropdownMenuItem>
-        <DropdownMenuItem
-          className="cursor-pointer text-lg hover:text-2xl"
-          onClick={settingModalOpenHandler}
-        >
-          <div className="flex items-center gap-2 p-2">
-            <SettingsIcon className={IconCSS} />
-            <span className={IconDescriptionCSS}>시스템</span>
-          </div>
-        </DropdownMenuItem>
       </DropdownMenuContent>
-      <SettingModal open={settingModalOpen} toggleOpen={setSettingModalOpen} />
     </DropdownMenu>
   );
 };

--- a/src/components/Layout/Sidebar/config.ts
+++ b/src/components/Layout/Sidebar/config.ts
@@ -5,15 +5,18 @@ export const LINKS = [
     url: "/",
     icon: HomeIcon,
     name: "홈",
+    requireAuth: false,
   },
   {
     url: "/my-notifications",
     icon: BellRingIcon,
     name: "내 알림",
+    requireAuth: true
   },
   {
     url: "/my-threads",
     icon: PenSquareIcon,
     name: "내가 쓴 글",
+    requireAuth: true
   },
 ];

--- a/src/components/Layout/Sidebar/config.ts
+++ b/src/components/Layout/Sidebar/config.ts
@@ -1,6 +1,6 @@
 import { BellRingIcon, HomeIcon, PenSquareIcon, SettingsIcon } from "lucide-react";
 
-export const LINKS = [
+export const SIDEBAR_ICONS = [
   {
     url: "/",
     icon: HomeIcon,

--- a/src/components/Layout/Sidebar/config.ts
+++ b/src/components/Layout/Sidebar/config.ts
@@ -1,4 +1,4 @@
-import { BellRingIcon, HomeIcon, PenSquareIcon } from "lucide-react";
+import { BellRingIcon, HomeIcon, PenSquareIcon, SettingsIcon } from "lucide-react";
 
 export const LINKS = [
   {
@@ -11,12 +11,18 @@ export const LINKS = [
     url: "/my-notifications",
     icon: BellRingIcon,
     name: "내 알림",
-    requireAuth: true
+    requireAuth: true,
   },
   {
     url: "/my-threads",
     icon: PenSquareIcon,
     name: "내가 쓴 글",
-    requireAuth: true
+    requireAuth: true,
+  },
+  {
+    url: "",
+    icon: SettingsIcon,
+    name: "시스템",
+    requireAuth: true,
   },
 ];

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -9,6 +9,7 @@ import { getLocalStorage } from "@/utils/localStorage";
 
 import LoginModal from "../Modals/Login";
 import RegisterModal from "../Modals/Register";
+import SettingModal from "../Modals/Setting";
 
 import { SIDEBAR_ICONS } from "./config";
 import { ThemeConfigDropdown } from "./ThemeConfigDropdown";
@@ -45,6 +46,7 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
 
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [registerModalOpen, setRegisterModalOpen] = useState(false);
+  const [settingModalOpen, setSettingModalOpen] = useState(false);
 
   const { mutate: logout } = usePostLogout();
 
@@ -81,6 +83,7 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
           openLoginModal={setLoginModalOpen}
         />
       )}
+      {isLoggedIn && <SettingModal open={settingModalOpen} toggleOpen={setSettingModalOpen} />}
       <div className="flex w-20 flex-col items-center justify-between gap-8">
         <div className="mt-4 flex cursor-pointer select-none flex-col items-center gap-2">
           <Avatar onClick={() => setLoginModalOpen(true)} className="flex items-center">

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -5,6 +5,8 @@ import { LogOut } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
+import { getLocalStorage } from "@/utils/localStorage";
+
 import LoginModal from "../Modals/Login";
 import RegisterModal from "../Modals/Register";
 
@@ -46,6 +48,8 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
 
   const { mutate: logout } = usePostLogout();
 
+  const isLoggedIn = !!getLocalStorage("token", "");
+
   const handleLogout = () => {
     logout();
   };
@@ -59,16 +63,20 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
   */
   return (
     <>
-      <LoginModal
-        open={loginModalOpen}
-        toggleOpen={setLoginModalOpen}
-        openRegisterModal={setRegisterModalOpen}
-      />
-      <RegisterModal
-        open={registerModalOpen}
-        toggleOpen={setRegisterModalOpen}
-        openLoginModal={setLoginModalOpen}
-      />
+      {!isLoggedIn && (
+        <LoginModal
+          open={loginModalOpen}
+          toggleOpen={setLoginModalOpen}
+          openRegisterModal={setRegisterModalOpen}
+        />
+      )}
+      {!isLoggedIn && (
+        <RegisterModal
+          open={registerModalOpen}
+          toggleOpen={setRegisterModalOpen}
+          openLoginModal={setLoginModalOpen}
+        />
+      )}
       <div className="flex w-20 flex-col items-center justify-between gap-8">
         <div className="mt-4 flex cursor-pointer select-none flex-col items-center gap-2">
           <Avatar onClick={() => setLoginModalOpen(true)} className="flex items-center">
@@ -109,12 +117,14 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
           </ThemeConfigDropdown>
         </div>
 
-        <button className={`${ButtonWrappingCSS} mb-6`} onClick={handleLogout}>
-          <div className={cn("relative", IconWrappingCSS)}>
-            <LogOut className={IconCSS} />
-          </div>
-          <span className={IconDescriptionCSS}>로그아웃</span>
-        </button>
+        {isLoggedIn && (
+          <button className={`${ButtonWrappingCSS} mb-6`} onClick={handleLogout}>
+            <div className={cn("relative", IconWrappingCSS)}>
+              <LogOut className={IconCSS} />
+            </div>
+            <span className={IconDescriptionCSS}>로그아웃</span>
+          </button>
+        )}
       </div>
     </>
   );

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -83,30 +83,32 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
             <AvatarImage src={profileImgUrl} alt={nickname} />
             <AvatarFallback>{shortenedNickname}</AvatarFallback>
           </Avatar>
-          {LINKS.map(({ url, name, icon: Icon }) => {
-            const isSelectedPage = pathname === url;
+          {LINKS.filter(({ requireAuth }) => !requireAuth || (requireAuth && isLoggedIn)).map(
+            ({ url, name, icon: Icon }) => {
+              const isSelectedPage = pathname === url;
 
-            return (
-              <Link key={url} to={url} className={ButtonWrappingCSS}>
-                <div
-                  className={cn(
-                    "relative",
-                    IconWrappingCSS,
-                    isSelectedPage && "bg-[rgba(124,40,82,0.25)] text-2xl",
-                  )}
-                >
-                  <Icon className={IconCSS} />
-                  {/* TODO: [2023-12-29] 지금처럼 url로 분기하지 않고 showBubble로 추상화하기 */}
-                  {url === "/my-notifications" && numberOfNotifications > 0 && (
-                    <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-2xl bg-[rgba(124,40,82,0.75)] text-xs text-white">
-                      {numberOfNotifications}
-                    </div>
-                  )}
-                </div>
-                <span className={IconDescriptionCSS}>{name}</span>
-              </Link>
-            );
-          })}
+              return (
+                <Link key={url} to={url} className={ButtonWrappingCSS}>
+                  <div
+                    className={cn(
+                      "relative",
+                      IconWrappingCSS,
+                      isSelectedPage && "bg-[rgba(124,40,82,0.25)] text-2xl",
+                    )}
+                  >
+                    <Icon className={IconCSS} />
+                    {/* TODO: [2023-12-29] 지금처럼 url로 분기하지 않고 showBubble로 추상화하기 */}
+                    {url === "/my-notifications" && numberOfNotifications > 0 && (
+                      <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-2xl bg-[rgba(124,40,82,0.75)] text-xs text-white">
+                        {numberOfNotifications}
+                      </div>
+                    )}
+                  </div>
+                  <span className={IconDescriptionCSS}>{name}</span>
+                </Link>
+              );
+            },
+          )}
           <ThemeConfigDropdown>
             <div className={ButtonWrappingCSS}>
               <div className={IconWrappingCSS}>

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -59,6 +59,10 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
   const handlerOpenSettingModal = () => {
     setSettingModalOpen(true);
   };
+
+  const handlerOpenLoginModal = () => {
+    setLoginModalOpen(true);
+  };
   /*
     Link Button과 DarkMode Dropdown 버튼이 공유하는 CSS가 많아서 styles로 상수화함.
     (Link를 쓰지 말고 navigate를 써도 될 듯)
@@ -86,7 +90,7 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
       {isLoggedIn && <SettingModal open={settingModalOpen} toggleOpen={setSettingModalOpen} />}
       <div className="flex w-20 flex-col items-center justify-between gap-8">
         <div className="mt-4 flex cursor-pointer select-none flex-col items-center gap-2">
-          <Avatar onClick={() => setLoginModalOpen(true)} className="flex items-center">
+          <Avatar onClick={handlerOpenLoginModal} className="flex items-center">
             <AvatarImage src={profileImgUrl} alt={nickname} />
             <AvatarFallback>{shortenedNickname}</AvatarFallback>
           </Avatar>

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -10,7 +10,7 @@ import { getLocalStorage } from "@/utils/localStorage";
 import LoginModal from "../Modals/Login";
 import RegisterModal from "../Modals/Register";
 
-import { LINKS } from "./config";
+import { SIDEBAR_ICONS } from "./config";
 import { ThemeConfigDropdown } from "./ThemeConfigDropdown";
 import { ButtonWrappingCSS, IconCSS, IconDescriptionCSS, IconWrappingCSS } from "./styles";
 
@@ -87,8 +87,9 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
             <AvatarImage src={profileImgUrl} alt={nickname} />
             <AvatarFallback>{shortenedNickname}</AvatarFallback>
           </Avatar>
-          {LINKS.filter(({ requireAuth }) => !requireAuth || (requireAuth && isLoggedIn)).map(
-            ({ url, name, icon: Icon }) => {
+          {SIDEBAR_ICONS.filter(
+            ({ requireAuth }) => !requireAuth || (requireAuth && isLoggedIn),
+          ).map(({ url, name, icon: Icon }) => {
             const isSelectedPage = pathname === url;
             const IconWrap = url ? Link : "button";
             const props = url ? { to: url } : { onClick: handlerOpenSettingModal, to: url };

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -53,6 +53,10 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
   const handleLogout = () => {
     logout();
   };
+
+  const handlerOpenSettingModal = () => {
+    setSettingModalOpen(true);
+  };
   /*
     Link Button과 DarkMode Dropdown 버튼이 공유하는 CSS가 많아서 styles로 상수화함.
     (Link를 쓰지 말고 navigate를 써도 될 듯)
@@ -85,30 +89,31 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
           </Avatar>
           {LINKS.filter(({ requireAuth }) => !requireAuth || (requireAuth && isLoggedIn)).map(
             ({ url, name, icon: Icon }) => {
-              const isSelectedPage = pathname === url;
+            const isSelectedPage = pathname === url;
+            const IconWrap = url ? Link : "button";
+            const props = url ? { to: url } : { onClick: handlerOpenSettingModal, to: url };
 
-              return (
-                <Link key={url} to={url} className={ButtonWrappingCSS}>
-                  <div
-                    className={cn(
-                      "relative",
-                      IconWrappingCSS,
-                      isSelectedPage && "bg-[rgba(124,40,82,0.25)] text-2xl",
-                    )}
-                  >
-                    <Icon className={IconCSS} />
-                    {/* TODO: [2023-12-29] 지금처럼 url로 분기하지 않고 showBubble로 추상화하기 */}
-                    {url === "/my-notifications" && numberOfNotifications > 0 && (
-                      <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-2xl bg-[rgba(124,40,82,0.75)] text-xs text-white">
-                        {numberOfNotifications}
-                      </div>
-                    )}
-                  </div>
-                  <span className={IconDescriptionCSS}>{name}</span>
-                </Link>
-              );
-            },
-          )}
+            return (
+              <IconWrap key={url} {...props} className={ButtonWrappingCSS}>
+                <div
+                  className={cn(
+                    "relative",
+                    IconWrappingCSS,
+                    isSelectedPage && "bg-[rgba(124,40,82,0.25)] text-2xl",
+                  )}
+                >
+                  <Icon className={IconCSS} />
+                  {/* TODO: [2023-12-29] 지금처럼 url로 분기하지 않고 showBubble로 추상화하기 */}
+                  {url === "/my-notifications" && numberOfNotifications > 0 && (
+                    <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-2xl bg-[rgba(124,40,82,0.75)] text-xs text-white">
+                      {numberOfNotifications}
+                    </div>
+                  )}
+                </div>
+                <span className={IconDescriptionCSS}>{name}</span>
+              </IconWrap>
+            );
+          })}
           <ThemeConfigDropdown>
             <div className={ButtonWrappingCSS}>
               <div className={IconWrappingCSS}>

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -61,7 +61,7 @@ export const SidebarView = ({ pathname, user, numberOfNotifications, theme }: Pr
   };
 
   const handlerOpenLoginModal = () => {
-    setLoginModalOpen(true);
+    if (!isLoggedIn) setLoginModalOpen(true);
   };
   /*
     Link Button과 DarkMode Dropdown 버튼이 공유하는 CSS가 많아서 styles로 상수화함.


### PR DESCRIPTION
## 📝 작업 내용

- 사이드바 아이콘 배열에 `requireAuth` 프로퍼티를 추가하여 로그인 여부에 따라 분기처리를 할 수 있게 했습니다.

- 스토리지에 저장된 토큰 여부에 따라 로그인 여부를 판단하여 모달, 아이콘 분기처리를 했습니다.

- 로그아웃 성공 후 path가 루트가 아닌 경우 루트로 리다이렉션

- 테마 설정 > 라이트, 다크, 시스템에서 시스템을 밖 사이드바로 분리했습니다.
    - 논의가 안된 상황인데 코드를 수정해서 죄송합니다.. 리뷰 요구사항에 구체적으로 적어놓았습니다!

### 📷 스크린샷

<img width=700 src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/18746dc1-a92d-4690-ac6e-e5f542daa99e" />

## 💬 리뷰 요구사항

- 테마 설정 > 라이트, 다크, 시스템 부분에서 이름이 테마 설정인데 시스템이 들어가있는 것에 대한 의문이 들어 우선 밖으로 빼내보았습니다.
    - 배포에 급해 코드를 우선적으로 확인해주셨음 해서 작업했습니다. 의견 달아주시면 커밋을 되돌리거나 추가 작업을 하겠습니다! :D

- (질문) 로그인 여부에 따른 분기처리를 하면서 시스템은 `Link` 태그가 필요없으므로 `Link` 태그와 `button` 태그를 나누어 출력되도록 했습니다.

```tsx
// components/Layout/Sidebar/view.tsx
// line 101

const IconWrap = url ? Link : "button";
const props = url ? { to: url } : { onClick: handlerOpenSettingModal, to: url };

return (
      <IconWrap key={url} {...props} className={ButtonWrappingCSS}>
```
그런데 `props`에 태그와 관련한 값을 할당할 때 `IconWrap`가 버튼인 경우에는 `to` 속성이 필요없는데, **`to` 속성을 입력하지 않으면** `undefined`는 허용하지 않는다고 `IconWrap` 태그에 에러가 뜹니다. `props`의 타입을 보니 아래로 뜨는데 `to` 속성이 버튼에는 필요없는 속성임에도 지정하는 방법 밖에 없는지 궁금합니다.

```ts
{
    to: string;
    onClick?: undefined;
} | {
    onClick: () => void;
    to?: undefined;      // << 이 부분
}
```

- 이 이외의 리뷰(변수명, 로직, 컨벤션 등)은 편하게 해주시면 감사하겠습니다 :D

close #92 
