### PR TITLE
[#87] Feat: 좋아요 알림 api와 커스텀 훅 구현 및 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "date-fns": "^3.0.6",
     "embla-carousel-react": "^8.0.0-rc17",
     "lucide-react": "^0.302.0",
+    "nanoid": "^5.0.4",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.2.0",

--- a/src/apis/thread/queryFn.ts
+++ b/src/apis/thread/queryFn.ts
@@ -45,7 +45,7 @@ export const getThreadsByChannelId = async (channelId: string) => {
 };
 
 export const postThreadLike = (threadId: string) =>
-  api.post({ url: "/likes/create", data: { threadId } });
+  api.post<Like>({ url: "/likes/create", data: { postId: threadId } });
 
 export const deleteThreadLike = (postId: string) =>
   api.delete<Like>({ url: "/likes/delete", data: { id: postId } });

--- a/src/apis/thread/queryFn.ts
+++ b/src/apis/thread/queryFn.ts
@@ -25,7 +25,6 @@ export const patchThread = async (postInfo: PatchThread) => {
   return await api.put<Thread>({ url: `/posts/update`, data: postInfo });
 };
 
-
 export const getThreadsByChannelId = async (channelId: string) => {
   const threads = await api.get<Thread[]>({ url: `/posts/channel/${channelId}` });
 
@@ -45,8 +44,8 @@ export const getThreadsByChannelId = async (channelId: string) => {
   });
 };
 
-export const postThreadLike = (postId: string) =>
-  api.post({ url: "/likes/create", data: { postId } });
+export const postThreadLike = (threadId: string) =>
+  api.post({ url: "/likes/create", data: { threadId } });
 
 export const deleteThreadLike = (postId: string) =>
   api.delete<Like>({ url: "/likes/delete", data: { id: postId } });

--- a/src/apis/thread/usePostThreadLike.ts
+++ b/src/apis/thread/usePostThreadLike.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { Thread } from "@/types/thread";
+import { Like, Thread } from "@/types/thread";
 
 import { postThreadLike } from "./queryFn";
 import threads from "./queryKey";
@@ -8,14 +8,19 @@ import threads from "./queryKey";
 const usePostThreadLike = (channelId: string) => {
   const queryClient = useQueryClient();
 
-  const { mutate, isPending, isError } = useMutation({
+  const { mutate, isPending, isError } = useMutation<
+    Like,
+    Error,
+    string,
+    { previousThreads: Thread[] | undefined }
+  >({
     mutationFn: (threadId: string) => postThreadLike(threadId),
     onMutate: async (threadId) => {
       await queryClient.cancelQueries({
         queryKey: threads.threadsByChannel(channelId).queryKey,
       });
 
-      const previousThreads = queryClient.getQueryData(
+      const previousThreads = queryClient.getQueryData<Thread[]>(
         threads.threadsByChannel(channelId).queryKey,
       );
 

--- a/src/apis/thread/usePostThreadLike.ts
+++ b/src/apis/thread/usePostThreadLike.ts
@@ -9,8 +9,8 @@ const usePostThreadLike = (channelId: string) => {
   const queryClient = useQueryClient();
 
   const { mutate, isPending, isError } = useMutation({
-    mutationFn: (postId: string) => postThreadLike(postId),
-    onMutate: async (postId) => {
+    mutationFn: (threadId: string) => postThreadLike(threadId),
+    onMutate: async (threadId) => {
       await queryClient.cancelQueries({
         queryKey: threads.threadsByChannel(channelId).queryKey,
       });
@@ -23,7 +23,7 @@ const usePostThreadLike = (channelId: string) => {
         threads.threadsByChannel(channelId).queryKey,
         (oldThreads: Thread[]) =>
           oldThreads.map((thread) =>
-            thread._id === postId ? { ...thread, likes: [...thread.likes, postId] } : thread,
+            thread._id === threadId ? { ...thread, likes: [...thread.likes, threadId] } : thread,
           ),
       );
 

--- a/src/apis/thread/usePostThreadLike.ts
+++ b/src/apis/thread/usePostThreadLike.ts
@@ -1,12 +1,16 @@
+import { nanoid } from "nanoid";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { Like, Thread } from "@/types/thread";
+
+import useGetUserInfo from "../auth/useGetUserInfo";
 
 import { postThreadLike } from "./queryFn";
 import threads from "./queryKey";
 
 const usePostThreadLike = (channelId: string) => {
   const queryClient = useQueryClient();
+  const { user } = useGetUserInfo();
 
   const { mutate, isPending, isError } = useMutation<
     Like,
@@ -24,11 +28,21 @@ const usePostThreadLike = (channelId: string) => {
         threads.threadsByChannel(channelId).queryKey,
       );
 
+      const optimisticLike = {
+        _id: nanoid(),
+        post: threadId,
+        user: user?._id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
       queryClient.setQueryData(
         threads.threadsByChannel(channelId).queryKey,
         (oldThreads: Thread[]) =>
           oldThreads.map((thread) =>
-            thread._id === threadId ? { ...thread, likes: [...thread.likes, threadId] } : thread,
+            thread._id === threadId
+              ? { ...thread, likes: [...thread.likes, optimisticLike] }
+              : thread,
           ),
       );
 

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -13,8 +13,8 @@ import ThreadToolbar from "./ThreadToolbar";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 import useDeleteThreadLike from "@/apis/thread/useDeleteThreadLike";
-import usePostThreadLike from "@/apis/thread/usePostThreadLike";
 import useDeleteThread from "@/apis/thread/useDeleteThread";
+import useLikeThread from "@/hooks/api/useLikeThread";
 
 interface Props {
   id: string;
@@ -27,7 +27,7 @@ interface Props {
 
 const ThreadListItem = ({ id, content, author, createdAt, likes, channelId }: Props) => {
   const { user } = useGetUserInfo();
-  const { likeThread } = usePostThreadLike(channelId);
+  const { likeAndNotify } = useLikeThread(channelId);
   const { removeLike } = useDeleteThreadLike(channelId);
   const [hoveredListId, setHoveredListId] = useState<string | null>(null);
   const likedByUser = likes.find((like) => like.user === user?._id);
@@ -44,7 +44,7 @@ const ThreadListItem = ({ id, content, author, createdAt, likes, channelId }: Pr
 
   const handleClickLikeButton = () => {
     if (isAlreadyLikedByUser) removeLike(likedByUser._id);
-    else likeThread(id);
+    else likeAndNotify({ threadId: id, authorId: author._id });
   };
 
   const handleDelete = () => {

--- a/src/constants/notification.ts
+++ b/src/constants/notification.ts
@@ -1,0 +1,6 @@
+export const NOTIFICATION_TYPES = {
+  COMMENT: "COMMENT",
+  FOLLOW: "FOLLOW",
+  LIKE: "LIKE",
+  MESSAGE: "MESSAGE",
+} as const;

--- a/src/hooks/api/useLikeThread.ts
+++ b/src/hooks/api/useLikeThread.ts
@@ -1,0 +1,29 @@
+import { Like } from "@/types/thread";
+
+import { usePostNotification } from "@/apis/notification/usePostNotification.ts";
+import usePostThreadLike from "@/apis/thread/usePostThreadLike";
+import { NOTIFICATION_TYPES } from "@/constants/notification";
+
+const useLikeThread = (channelId: string) => {
+  const { likeThread, isPending } = usePostThreadLike(channelId);
+  const { mutate: notificationMutate } = usePostNotification();
+
+  const likeAndNotify = ({ threadId, authorId }: { threadId: string; authorId: string }) => {
+    likeThread(threadId, {
+      onSuccess: (like: Like) => {
+        const notificationRequest = {
+          notificationType: NOTIFICATION_TYPES.LIKE,
+          notificationTypeId: like._id,
+          userId: authorId,
+          postId: threadId,
+        };
+
+        notificationMutate(notificationRequest);
+      },
+    });
+  };
+
+  return { likeAndNotify, isPending };
+};
+
+export default useLikeThread;

--- a/src/hooks/api/useMentionNotification.ts
+++ b/src/hooks/api/useMentionNotification.ts
@@ -1,7 +1,7 @@
 import { usePostNotification } from "@/apis/notification/usePostNotification.ts";
 import { usePostMention } from "@/apis/mention/usePostMention.ts";
-import { NotificationTypes } from "@/apis/notification/queryFn.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
+import { NOTIFICATION_TYPES } from "@/constants/notification";
 
 interface MentionNotificationProps {
   content: string;
@@ -26,7 +26,7 @@ const useMentionNotification = ({ mentionList }: Props) => {
       const mentionResponse = await mentionMutate(mentionRequest);
 
       const notificationRequest = {
-        notificationType: "MESSAGE" as NotificationTypes,
+        notificationType: NOTIFICATION_TYPES.MESSAGE,
         notificationTypeId: mentionResponse._id,
         userId: mentionResponse.sender._id,
         postId,

--- a/src/hooks/api/useUploadComment.ts
+++ b/src/hooks/api/useUploadComment.ts
@@ -1,10 +1,10 @@
 import { usePostComment } from "@/apis/comment/usePostComment.ts";
 import { usePostNotification } from "@/apis/notification/usePostNotification.ts";
-import { NotificationTypes } from "@/apis/notification/queryFn.ts";
 import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
+import { NOTIFICATION_TYPES } from "@/constants/notification";
 
 interface Props {
   nickname: string | undefined;
@@ -30,7 +30,7 @@ const useUploadComment = ({ nickname, postId, channelName, mentionList, postAuth
     const commentResponse = await commentMutate(commentRequest);
 
     const notificationRequest = {
-      notificationType: "COMMENT" as NotificationTypes,
+      notificationType: NOTIFICATION_TYPES.COMMENT,
       notificationTypeId: commentResponse._id,
       userId: postAuthorId,
       postId,

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -15,13 +15,11 @@ const HomePage = () => {
       </div>
       <div className="w-full max-w-4xl px-4">
         <main>{threads && <ThreadList threads={threads} />}</main>
-        {user && (
-          <EditorTextArea
-            isMention={channelName !== "incompetent"}
-            nickname={user.nickname}
-            editorProps={{ channelId }}
-          />
-        )}
+        <EditorTextArea
+          isMention={channelName !== "incompetent"}
+          nickname={user?.nickname || ""}
+          editorProps={{ channelId }}
+        />
       </div>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,6 +3873,11 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+nanoid@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
+  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
## 📝 작업 내용

- 좋아요 요청 커스텀 훅과 알림 보내기 커스텀 훅을 사용하여 새로운 커스텀 훅 구현(useLikeThread)
- 기존에 문자열로 사용하던 `notificationTypes`를 상수화하여 타입 단언을 제거하고 자동 완성이 되도록 했습니다.
- nanoid 설치(yarn install을 새로 해주셔야 합니다!!)
- 낙관적 업데이트를 할때, 좋아요 객체를 생성하여 넣어주어야 합니다. 성공하면 새로 요청을, 실패하면 롤백을 하기 때문에 `_id`를 nanoid로 생성하여 넣어주었습니다.
- nanoid를 사용하지 않고 빈 문자열로 해두어도 문제가 되진 않지만 혹시 몰라 고유 id를 생성하여 넣어주었습니다.

## 💬 리뷰 요구사항

이상한 부분 지적해주시면 수정하겠습니다!


close #87
