### PR TITLE
[#101] Fix: 내 알림에 아무것도 없을 시 에러처리

### DIFF
--- a/src/components/MyNotifications/LikeNotification.tsx
+++ b/src/components/MyNotifications/LikeNotification.tsx
@@ -1,22 +1,20 @@
 import { formatDate } from "@/utils/formatDate.ts";
 
-import { Like } from "@/types/thread";
+import { LikeByNotification } from "@/types/thread";
+
+import { MyNotificationContent } from "@/components/MyNotifications/MyNotificationItem.tsx";
 
 interface Props {
   createdAt: string;
-  like: Like;
+  like: LikeByNotification;
 }
 
 const LikeNotification = ({ createdAt, like }: Props) => {
   const createdDate = formatDate(createdAt);
 
-  return (
-    <>
-      <div> 좋아요 알림</div>
-      <div> createdAt: {createdDate}</div>
-      <div> like: {like}</div>
-    </>
-  );
+  const { content } = JSON.parse(like.post.title);
+
+  return <MyNotificationContent createdDate={createdDate} content={content} isLike={true} />;
 };
 
 export default LikeNotification;

--- a/src/components/MyNotifications/LikeNotification.tsx
+++ b/src/components/MyNotifications/LikeNotification.tsx
@@ -14,7 +14,14 @@ const LikeNotification = ({ createdAt, like }: Props) => {
 
   const { content } = JSON.parse(like.post.title);
 
-  return <MyNotificationContent createdDate={createdDate} content={content} isLike={true} />;
+  return (
+    <MyNotificationContent
+      createdDate={createdDate}
+      content={content}
+      postId={like.post._id}
+      isLike={true}
+    />
+  );
 };
 
 export default LikeNotification;

--- a/src/components/MyNotifications/LikeNotification.tsx
+++ b/src/components/MyNotifications/LikeNotification.tsx
@@ -1,0 +1,22 @@
+import { formatDate } from "@/utils/formatDate.ts";
+
+import { Like } from "@/types/thread";
+
+interface Props {
+  createdAt: string;
+  like: Like;
+}
+
+const LikeNotification = ({ createdAt, like }: Props) => {
+  const createdDate = formatDate(createdAt);
+
+  return (
+    <>
+      <div> 좋아요 알림</div>
+      <div> createdAt: {createdDate}</div>
+      <div> like: {like}</div>
+    </>
+  );
+};
+
+export default LikeNotification;

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -11,7 +11,7 @@ const isComment = (props: Notification | Conversation): props is Notification =>
 };
 
 const isLike = (props: Notification | Conversation): props is Notification => {
-  return "like" in props;
+  return "like" in props && props.like !== null;
 };
 
 const isMention = (props: Notification | Conversation): props is Notification => {
@@ -27,7 +27,7 @@ const isMention = (props: Notification | Conversation): props is Notification =>
 
 const MyNotificationBody = () => {
   const { listedNotificationAndMention, isPending } = useListedNotificationAndMention();
-
+  console.log("listedNotificationAndMention", listedNotificationAndMention);
   if (isPending) {
     return <span>Loading...</span>;
   }
@@ -72,8 +72,6 @@ const MyNotificationBody = () => {
               />
             );
           }
-
-          return <div key={typeof _id === "string" ? _id : _id[0]}>알림이 없습니다.</div>;
         })}
       </ul>
     </main>

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -51,6 +51,7 @@ const MyNotificationBody = () => {
               />
             );
           }
+
           if (isLike(notification)) {
             const { like } = notification;
             return (

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -1,4 +1,5 @@
 import { Conversation, Notification } from "@/types/notification";
+import { LikeByNotification } from "@/types/thread.ts";
 
 import LikeNotification from "./LikeNotification";
 
@@ -11,7 +12,7 @@ const isComment = (props: Notification | Conversation): props is Notification =>
 };
 
 const isLike = (props: Notification | Conversation): props is Notification => {
-  return "like" in props && props.like !== null;
+  return "like" in props && !!props.like;
 };
 
 const isMention = (props: Notification | Conversation): props is Notification => {
@@ -27,7 +28,6 @@ const isMention = (props: Notification | Conversation): props is Notification =>
 
 const MyNotificationBody = () => {
   const { listedNotificationAndMention, isPending } = useListedNotificationAndMention();
-  console.log("listedNotificationAndMention", listedNotificationAndMention);
   if (isPending) {
     return <span>Loading...</span>;
   }
@@ -52,13 +52,12 @@ const MyNotificationBody = () => {
             );
           }
           if (isLike(notification)) {
-            console.log("likenoti", notification);
             const { like } = notification;
             return (
               <LikeNotification
                 key={typeof _id === "string" ? _id : _id[0]}
+                like={like as LikeByNotification}
                 createdAt={createdAt}
-                like={like}
               />
             );
           }

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -8,6 +8,14 @@ const isComment = (props: Notification | Conversation): props is Notification =>
   return "comment" in props;
 };
 
+const isLike = (props: Notification | Conversation): props is Notification => {
+  return "like" in props;
+};
+
+const isMention = (props: Notification | Conversation): props is Notification => {
+  return "message" in props;
+};
+
 const MyNotificationBody = () => {
   const { listedNotificationAndMention, isPending } = useListedNotificationAndMention();
 
@@ -34,14 +42,21 @@ const MyNotificationBody = () => {
               />
             );
           }
+          if (isLike(notification)) {
+            return <div>아직 안 만들었어요~!</div>;
+          }
 
-          return (
-            <MentionNotification
-              key={typeof _id === "string" ? _id : _id[0]}
-              message={message || ""}
-              createdAt={createdAt}
-            />
-          );
+          if (isMention(notification)) {
+            return (
+              <MentionNotification
+                key={typeof _id === "string" ? _id : _id[0]}
+                message={message || ""}
+                createdAt={createdAt}
+              />
+            );
+          }
+
+          return <div>알림이 없습니다.</div>;
         })}
       </ul>
     </main>

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -1,5 +1,7 @@
 import { Conversation, Notification } from "@/types/notification";
 
+import LikeNotification from "./LikeNotification";
+
 import useListedNotificationAndMention from "@/hooks/api/useListedNotificationAndMention.ts";
 import CommentNotification from "@/components/MyNotifications/CommentNotification.tsx";
 import MentionNotification from "@/components/MyNotifications/MentionNotification.tsx";
@@ -43,7 +45,15 @@ const MyNotificationBody = () => {
             );
           }
           if (isLike(notification)) {
-            return <div>아직 안 만들었어요~!</div>;
+            console.log("likenoti", notification);
+            const { like } = notification;
+            return (
+              <LikeNotification
+                key={typeof _id === "string" ? _id : _id[0]}
+                createdAt={createdAt}
+                like={like}
+              />
+            );
           }
 
           if (isMention(notification)) {

--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -56,7 +56,7 @@ const MyNotificationBody = () => {
             );
           }
 
-          return <div>알림이 없습니다.</div>;
+          return <div key={typeof _id === "string" ? _id : _id[0]}>알림이 없습니다.</div>;
         })}
       </ul>
     </main>

--- a/src/components/MyNotifications/MyNotificationItem.tsx
+++ b/src/components/MyNotifications/MyNotificationItem.tsx
@@ -5,10 +5,21 @@ interface Props {
   content: string;
   channelName?: string;
   postId?: string;
+  isLike?: boolean;
   isMention?: boolean;
 }
-export const MyNotificationContent = ({ createdDate, content, channelName, isMention }: Props) => {
-  const title = channelName ? `#${channelName}에서 멘션이 왔어요!` : "댓글이 달렸어요!";
+export const MyNotificationContent = ({
+  createdDate,
+  content,
+  channelName,
+  isMention,
+  isLike,
+}: Props) => {
+  const title = channelName
+    ? `#${channelName}에서 멘션이 왔어요!`
+    : isLike
+      ? "like"
+      : "댓글이 달렸어요!";
   return (
     <li>
       <div className="flex items-center justify-between gap-6 pt-6">

--- a/src/components/MyNotifications/MyNotificationItem.tsx
+++ b/src/components/MyNotifications/MyNotificationItem.tsx
@@ -4,7 +4,7 @@ interface Props {
   createdDate: string;
   content: string;
   channelName?: string;
-  postId?: string;
+  postId: string;
   isLike?: boolean;
   isMention?: boolean;
 }
@@ -13,6 +13,7 @@ export const MyNotificationContent = ({
   content,
   channelName,
   isMention,
+  postId,
   isLike,
 }: Props) => {
   const title = channelName
@@ -20,6 +21,8 @@ export const MyNotificationContent = ({
     : isLike
       ? "like"
       : "댓글이 달렸어요!";
+
+  console.log("postId", postId);
   return (
     <li>
       <div className="flex items-center justify-between gap-6 pt-6">

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,6 +1,5 @@
-import { Comment } from "./thread";
+import { Comment, LikeByNotification } from "./thread";
 import { User } from "./user";
-import { Like } from "./thread";
 
 export interface Notification {
   seen: boolean;
@@ -9,7 +8,7 @@ export interface Notification {
   user: User | string;
   post: string | null;
   follow?: string;
-  like?: Like;
+  like?: LikeByNotification;
   comment?: Comment;
   message?: string;
   createdAt: string;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -9,6 +9,10 @@ export interface Like {
   updatedAt: string;
 }
 
+export interface LikeByNotification extends Omit<Like, "post"> {
+  post: Thread;
+}
+
 export interface Comment {
   _id: string;
   comment: string;


### PR DESCRIPTION
## 📝 작업 내용

내 알림에 like, comment, mention 3가지 경우가 있음 
  
- like를 취소할 경우 like : null로 변경됨 => null일 경우 error
    - null이 아닐 경우만 처리 하도록 타입가드로 해결 
  
- mention할 경우 Notification, Conversation 둘다 mention 필드가 있음 
  - 실제로 처리해야하는 경우는 Conversation
    - Notification에는 messageId, Conversation : message[] 가 넘어옴 
    - JSON.parse가 가능한 경우만 처리하도록 타입가드로 해결 

- Notification의 Like 타입의 post는  Like 생성, 삭제와 다른 값이 넘어와서 새로운 타입을 추가했습니다. (LikeByNotification)

## 💬 리뷰 요구사항
빠르게 버그 잡느라 타입단언도 사용하고 코드가 지저분합니다. 배포이후 리팩토링 해야합니다!!

close #101 
