### PR TITLE
[#41] Feat: 회원가입, 로그인 모달에서 에러 경고, 혹은 성공 토스트 메시지 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Toaster } from "sonner";
 
 import HomePage from "./pages/Home";
 import MyThreadsPage from "./pages/MyThreads";
@@ -8,6 +9,7 @@ import Layout from "./components/Layout";
 
 const App = () => (
   <BrowserRouter>
+    <Toaster position="bottom-center" />
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<HomePage />} />

--- a/src/apis/auth/useLogin.ts
+++ b/src/apis/auth/useLogin.ts
@@ -2,34 +2,17 @@ import { useMutation } from "@tanstack/react-query";
 
 import { setLocalStorage } from "@/utils/localStorage";
 
-import { postLogin, LoginRequest, AuthResponse } from "./queryFn";
+import { postLogin, LoginRequest } from "./queryFn";
 
 interface Props {
   toggleOpen: (open: boolean) => void;
 }
 
 const useLogin = ({ toggleOpen }: Props) => {
-  const parseUser = (data: AuthResponse) => {
-    const {
-      token,
-      user: { _id: id, email, fullName },
-    } = data;
-    const { name, nickname } = JSON.parse(fullName);
-    return {
-      id,
-      email,
-      name,
-      nickname,
-      token,
-      isLoggedIn: true,
-    };
-  };
-
   return useMutation({
     mutationFn: (body: LoginRequest) => postLogin(body),
-    onSuccess: (data) => {
-      const user = parseUser(data);
-      setLocalStorage("token", user.token);
+    onSuccess: ({ token }) => {
+      setLocalStorage("token", token);
       toggleOpen(false);
     },
   });

--- a/src/apis/auth/useLogin.ts
+++ b/src/apis/auth/useLogin.ts
@@ -9,13 +9,15 @@ interface Props {
 }
 
 const useLogin = ({ toggleOpen }: Props) => {
-  return useMutation({
+  const { mutateAsync } = useMutation({
     mutationFn: (body: LoginRequest) => postLogin(body),
     onSuccess: ({ token }) => {
       setLocalStorage("token", token);
       toggleOpen(false);
     },
   });
+
+  return { login: mutateAsync };
 };
 
 export default useLogin;

--- a/src/apis/auth/useLogin.ts
+++ b/src/apis/auth/useLogin.ts
@@ -30,8 +30,8 @@ const useLogin = ({ toggleOpen }: Props) => {
     onSuccess: (data) => {
       const user = parseUser(data);
       setLocalStorage("token", user.token);
+      toggleOpen(false);
     },
-    onSettled: () => toggleOpen(false),
   });
 };
 

--- a/src/apis/auth/usePostLogin.ts
+++ b/src/apis/auth/usePostLogin.ts
@@ -8,7 +8,7 @@ interface Props {
   toggleOpen: (open: boolean) => void;
 }
 
-const useLogin = ({ toggleOpen }: Props) => {
+const usePostLogin = ({ toggleOpen }: Props) => {
   const { mutateAsync } = useMutation({
     mutationFn: (body: LoginRequest) => postLogin(body),
     onSuccess: ({ token }) => {
@@ -20,4 +20,4 @@ const useLogin = ({ toggleOpen }: Props) => {
   return { login: mutateAsync };
 };
 
-export default useLogin;
+export default usePostLogin;

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
-  const { mutate: loginMutate } = useLogin({ toggleOpen });
+  const { mutate: login } = useLogin({ toggleOpen });
 
   const handleRegisterClick = () => {
     toggleOpen(!open);
@@ -25,7 +25,7 @@ const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
 
   const handleSubmit = (loginInfo: z.infer<typeof LOGIN_FIELDS_SCHEMA>) => {
     // TODO: 에러 모달 처리 (2024-01-01)
-    loginMutate(loginInfo);
+    login(loginInfo);
   };
 
   return (

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -9,7 +9,7 @@ import SimpleBaseModal from "../Base/modal";
 
 import { LOGIN_FIELDS, LOGIN_FIELDS_SCHEMA } from "./config";
 
-import useLogin from "@/apis/auth/useLogin";
+import usePostLogin from "@/apis/auth/usePostLogin";
 import { AUTH_ERROR_MESSAGE, AUTH_ERROR_RESPONSE } from "@/constants/authError";
 
 interface Props {
@@ -19,7 +19,7 @@ interface Props {
 }
 
 const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
-  const { login } = useLogin({ toggleOpen });
+  const { login } = usePostLogin({ toggleOpen });
 
   const handleRegisterClick = () => {
     toggleOpen(!open);

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { toast } from "sonner";
+import { AxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
 
@@ -8,6 +10,7 @@ import SimpleBaseModal from "../Base/modal";
 import { LOGIN_FIELDS, LOGIN_FIELDS_SCHEMA } from "./config";
 
 import useLogin from "@/apis/auth/useLogin";
+import { AUTH_ERROR_MESSAGE, AUTH_ERROR_RESPONSE } from "@/constants/authError";
 
 interface Props {
   open: boolean;
@@ -24,8 +27,19 @@ const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
   };
 
   const handleSubmit = (loginInfo: z.infer<typeof LOGIN_FIELDS_SCHEMA>) => {
-    // TODO: 에러 모달 처리 (2024-01-01)
-    login(loginInfo);
+    toast.promise(login(loginInfo), {
+      loading: "잠시만 기다려주세요...",
+      success: ({ user: { fullName } }) => {
+        const { nickname } = JSON.parse(fullName);
+        return `어서오세요, ${nickname}님!`;
+      },
+      error: (error: AxiosError) => {
+        if (error?.response?.data === AUTH_ERROR_RESPONSE.LOGIN_FAILED) {
+          return AUTH_ERROR_MESSAGE.LOGIN_FAILED;
+        }
+        return AUTH_ERROR_MESSAGE.SERVER_ERROR;
+      },
+    });
   };
 
   return (

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const LoginModal = ({ open, toggleOpen, openRegisterModal }: Props) => {
-  const { mutate: login } = useLogin({ toggleOpen });
+  const { login } = useLogin({ toggleOpen });
 
   const handleRegisterClick = () => {
     toggleOpen(!open);

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -49,8 +49,9 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
     const fullName = { name, nickname: nickname || ANONYMOUS_NICKNAME };
     toast.promise(updateUserList({ email, fullName, password }), {
       loading: "잠시만 기다려주세요...",
-      success: () => {
-        return "회원가입에 성공했습니다.";
+      success: (name) => {
+        // TODO: handleLoginClick()이 여기서 안 먹는 이유 찾기 (2024-01-10)
+        return `환영합니다, ${name}님!`;
       },
       error: () => {
         return "회원가입에 실패했습니다. 다시 시도해주세요.";

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -41,9 +41,8 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
   const handleSubmit = async (registerInfo: z.infer<typeof REGISTER_FIELDS_SCHEMA>) => {
     const { email, name, nickname, password } = registerInfo;
 
-    // TODO: [24/1/9] alert 변경할 것
     if (!userListByDB.find((user) => user.name === name)) {
-      alert("없는 회원 입니다.");
+      toast.warning(AUTH_ERROR_MESSAGE.UNKNOWN_NAME);
       return;
     }
     const fullName = { name, nickname: nickname || ANONYMOUS_NICKNAME };

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -53,7 +53,7 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
         if (error?.response?.data === AUTH_ERROR_RESPONSE.ALREADY_USED_EMAIL) {
           return AUTH_ERROR_MESSAGE.ALREADY_USED_EMAIL;
         }
-        return "회원가입에 실패했습니다. 다시 시도해주세요.";
+        return AUTH_ERROR_MESSAGE.SERVER_ERROR;
       },
     });
   };

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { useCallback, useEffect } from "react";
 import { isAxiosError } from "axios";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 
@@ -46,7 +47,15 @@ const RegisterModal = ({ open, toggleOpen, openLoginModal }: Props) => {
       return;
     }
     const fullName = { name, nickname: nickname || ANONYMOUS_NICKNAME };
-    await updateUserList({ email, fullName, password });
+    toast.promise(updateUserList({ email, fullName, password }), {
+      loading: "잠시만 기다려주세요...",
+      success: () => {
+        return "회원가입에 성공했습니다.";
+      },
+      error: () => {
+        return "회원가입에 실패했습니다. 다시 시도해주세요.";
+      },
+    });
   };
 
   return (

--- a/src/constants/authError.ts
+++ b/src/constants/authError.ts
@@ -1,8 +1,10 @@
 export const AUTH_ERROR_RESPONSE = {
   ALREADY_USED_EMAIL: "The email address is already being used.",
+  LOGIN_FAILED: "Your email and password combination does not match an account.",
 };
 
 export const AUTH_ERROR_MESSAGE = {
   UNKNOWN_NAME: "없는 프롱이 입니다.",
   ALREADY_USED_EMAIL: "이미 사용중인 이메일 입니다.",
+  LOGIN_FAILED: "이메일과 비밀번호가 일치하지 않습니다.",
 };

--- a/src/constants/authError.ts
+++ b/src/constants/authError.ts
@@ -7,4 +7,5 @@ export const AUTH_ERROR_MESSAGE = {
   UNKNOWN_NAME: "없는 프롱이 입니다.",
   ALREADY_USED_EMAIL: "이미 사용중인 이메일 입니다.",
   LOGIN_FAILED: "이메일과 비밀번호가 일치하지 않습니다.",
+  SERVER_ERROR: "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요.",
 };

--- a/src/constants/authError.ts
+++ b/src/constants/authError.ts
@@ -1,0 +1,8 @@
+export const AUTH_ERROR_RESPONSE = {
+  ALREADY_USED_EMAIL: "The email address is already being used.",
+};
+
+export const AUTH_ERROR_MESSAGE = {
+  UNKNOWN_NAME: "없는 프롱이 입니다.",
+  ALREADY_USED_EMAIL: "이미 사용중인 이메일 입니다.",
+};

--- a/src/hooks/api/useUpdateUserList.ts
+++ b/src/hooks/api/useUpdateUserList.ts
@@ -1,7 +1,7 @@
 import { RegisterRequest } from "@/apis/auth/queryFn.ts";
 import useChangeThread from "@/hooks/api/useChangeThread.ts";
 import useUserListByDB from "@/hooks/api/useUserListByDB.ts";
-import useLogin from "@/apis/auth/useLogin.ts";
+import usePostLogin from "@/apis/auth/usePostLogin";
 import usePostLogout from "@/apis/auth/usePostLogout.ts";
 import useRegister from "@/apis/auth/useRegister.ts";
 
@@ -11,7 +11,7 @@ const useUpdateUserList = () => {
     nickname: "데브코스 관리자",
     postId: import.meta.env.VITE_ADMIN_DB,
   });
-  const { login } = useLogin({ toggleOpen: () => {} });
+  const { login } = usePostLogin({ toggleOpen: () => { } });
   const { userListByDB } = useUserListByDB();
   const { mutate: logoutMutate } = usePostLogout();
 

--- a/src/hooks/api/useUpdateUserList.ts
+++ b/src/hooks/api/useUpdateUserList.ts
@@ -37,6 +37,8 @@ const useUpdateUserList = () => {
     });
 
     logoutMutate();
+
+    return name;
   };
 
   return {

--- a/src/hooks/api/useUpdateUserList.ts
+++ b/src/hooks/api/useUpdateUserList.ts
@@ -11,7 +11,7 @@ const useUpdateUserList = () => {
     nickname: "데브코스 관리자",
     postId: import.meta.env.VITE_ADMIN_DB,
   });
-  const { mutateAsync: loginMutate } = useLogin({ toggleOpen: () => {} });
+  const { login } = useLogin({ toggleOpen: () => {} });
   const { userListByDB } = useUserListByDB();
   const { mutate: logoutMutate } = usePostLogout();
 
@@ -26,7 +26,7 @@ const useUpdateUserList = () => {
       user.name === name ? { ...user, userId: _id } : user,
     );
 
-    await loginMutate({
+    await login({
       email: import.meta.env.VITE_ADMIN_ID,
       password: import.meta.env.VITE_ADMIN_PW,
     });


### PR DESCRIPTION
## 📝 작업 내용

- 성공/실패 시 토스트 메시지 띄우게 처리([shadcn sooner](https://ui.shadcn.com/docs/components/sonner) 이용)

- 성공한 경우에만 모달 닫히도록 처리

- 로딩중, 성공, 실패 메시지 상수 설정

- `toast.promise(func, ...)`에 프로미스를 반환하는 함수가 들어가야해서 `mutateAsync` 사용(`mutate`는 `void` 반환)
    - 로그인 쿼리에서는 `mutateAsync`만 사용하여 재훈님이 작업하신 부분과 함께 간단한 리팩토링을 했습니다.
        - `usePostLogin` 커스텀 훅에서 `return { login: mutateAsync }`으로 반환하여 바로 `login`으로 mutate 할 수 있도록 처리했습니다.

### 📷 스크린샷

<img width=650 src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/00586311-bbeb-486c-8584-f531c52103c1" />

## 💬 리뷰 요구사항

- 변수명, 메시지 문구 적절한지 부탁드립니다!

- 성공 메시지들도 상수 처리 하는게 좋은지 고민입니다!

- [sooner Docs](https://sonner.emilkowal.ski/)에서 여러 메시지나 포지션을 지원하는데 한번 보시고 다르게 고쳐도 될 것 같다 하시면 편하게 말씀 주세요!

- toast.promise는 따로 utils로 빼서 메서드처럼 사용하게 만들까 고민 중 입니다! :D (프로필 변경도 처리해야해서 이 업무 후 할 것 같습니다)

close #41
