### PR TITLE
[#105] Feat: QA 이후 배포 전 EditerTextArea 수정사항 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Toaster } from "sonner";
 
 import HomePage from "./pages/Home";
 import MyThreadsPage from "./pages/MyThreads";
@@ -8,6 +9,7 @@ import Layout from "./components/Layout";
 
 const App = () => (
   <BrowserRouter>
+    <Toaster position="bottom-center" />
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<HomePage />} />

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -81,7 +81,7 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
 
       <form className="relative">
         <Textarea
-          placeholder={`내용을 작성해주세요.`}
+          placeholder={user ? `내용을 작성해주세요.` : "로그인이 필요합니다."}
           className="resize-none text-base"
           {...register("content")}
         />

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -83,7 +83,7 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
   if (isPending) return <div>로딩 중... </div>;
 
   return (
-    <div className="text- flex w-full flex-col gap-1 ">
+    <div className="flex w-full flex-col gap-1 ">
       {isMention && <MentionInput mentionList={mentionList} onChoose={setMentionList} />}
 
       <form className="relative">

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { SendHorizontal } from "lucide-react";
 import { FormEvent, useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { Textarea } from "@/components/ui/textarea.tsx";
 
@@ -45,9 +46,15 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
 
   const handleUpload = (formValues: FormValues) => {
     if (!user) {
-      // TODO: alert 컴포넌트로 변경하기
-      alert("로그인이 필요합니다.");
-      setRegisterModalOpen((prev) => !prev);
+      // TODO: [24/1/11] 이거 나중에 함수로 빼는게 좋을듯해요!
+      toast("로그인 한 유저만 글 쓰기가 가능합니다.", {
+        action: {
+          label: "로그인",
+          onClick: () => setRegisterModalOpen((prev) => !prev),
+        },
+        duration: 2000,
+      });
+
       return;
     }
     upload(formValues);

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -57,13 +57,13 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
   };
 
   return (
-    <div className="flex w-full flex-col gap-1">
+    <div className="text- flex w-full flex-col gap-1 ">
       {isMention && <MentionInput mentionList={mentionList} onChoose={setMentionList} />}
 
       <form className="relative">
         <Textarea
           placeholder={`내용을 작성해주세요.`}
-          className="resize-none"
+          className="resize-none text-base"
           {...register("content")}
         />
         <div className="absolute bottom-2 right-2 flex items-center gap-2">

--- a/src/components/common/mention/MentionInput.tsx
+++ b/src/components/common/mention/MentionInput.tsx
@@ -91,6 +91,7 @@ const MentionInput = ({ mentionList, onChoose }: Props) => {
         onKeyDown={handleKeyDown}
         ref={inputRef}
         placeholder="멘션할 대상을 선택해주세요."
+        className="text-base"
       />
 
       <AutoCompleteMentionList


### PR DESCRIPTION
## 📝 작업 내용

1. 스레드의 content와  폰트 사이즈 통일 
2. 비회원이 에디터 입력 시  → alert(로그인 필요함) -> 로그인/회원가입 모달로 이동
3. 익명이름 없을 경우 익명 클릭 시-> 내 프로필 편집 모달로 이동 

## 💬 리뷰 요구사항

제가 작성한 코드가 거의 없습니다ㅎ 

변경 사항인 User 여부와 모달은 

1.  로그인 판단
User 객체 존재 여부는 에디터에서 판단하는게 아닌 에디터를 보내주는 쪽에서 이미 User객체가 있기 때문에 받아와서 사용하는게 좋을 것 같습니다. 
하지만 현재 에디터 자세히보기 구현코드가 합쳐지지 않은 상태라 그냥 에디터에서 불러왔습니다. 
배포 이후 props로 넘겨주는 식으로 변경하는게 좋을 것 같습니다!

2. 모달 띄우기
여러곳에서 사용하는 모달은 Layout이나 App단으로 띄우고 사용하는곳에서는 트리거만 이용하기로 결정된것로 알고있습니다! 
하지만 이부분도 배포이후에 작업하기로 하였기 때문에 현재 에디터에서 sideBar의 코드를 그대로 가져오 모달을 다 불러오고(로그인, 회원가입, 정보변경) 처리하게 되었습니다.
이부분도 배포 이후 전역으로 오픈여부를 관리하며 에디터에서는 트리거 역할만 하도록 변경하는게 좋을 것 같습니다!! 

close #105 
