### PR TITLE
[#108] Feat: 내 알림, 내가 쓴 글이 비어있을 시 디폴트 내용 출력

### DIFF
--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -1,6 +1,8 @@
 import { Conversation, Notification } from "@/types/notification";
 import { LikeByNotification } from "@/types/thread.ts";
 
+import EmptyThread from "../common/myactivate/emptyThread";
+
 import LikeNotification from "./LikeNotification";
 
 import useListedNotificationAndMention from "@/hooks/api/useListedNotificationAndMention.ts";
@@ -30,6 +32,9 @@ const MyNotificationBody = () => {
   const { listedNotificationAndMention, isPending } = useListedNotificationAndMention();
   if (isPending) {
     return <span>Loading...</span>;
+  }
+  if (listedNotificationAndMention.length === 0) {
+    return <EmptyThread type="notification" />;
   }
 
   return (

--- a/src/components/MyNotifications/MyNotificationItem.tsx
+++ b/src/components/MyNotifications/MyNotificationItem.tsx
@@ -5,11 +5,18 @@ import { Separator } from "@/components/ui/separator";
 interface Props {
   createdDate: string;
   content: string;
-  channelName?: string;
+  channelName?: "compliment" | "cheering" | "incompetent";
   postId: string;
   isLike?: boolean;
   isMention?: boolean;
 }
+
+const channelMap = {
+  cheering: "응원",
+  compliment: "칭찬",
+  incompetent: "무능",
+};
+
 export const MyNotificationContent = ({
   createdDate,
   content,
@@ -19,9 +26,9 @@ export const MyNotificationContent = ({
   isLike,
 }: Props) => {
   const title = channelName
-    ? `#${channelName}에서 멘션이 왔어요!`
+    ? `#${channelMap[channelName]}게시판에서 멘션이 왔어요!`
     : isLike
-      ? "like"
+      ? "좋아요가 달렸어요!"
       : "댓글이 달렸어요!";
 
   const selectThreadId = useThreadStore((state) => state.selectThreadId);

--- a/src/components/MyThreads/MyThreadBody.tsx
+++ b/src/components/MyThreads/MyThreadBody.tsx
@@ -4,6 +4,8 @@ import { parseTitle } from "@/utils/parsingJson";
 
 import { Thread, Comment } from "@/types/thread.ts";
 
+import EmptyThread from "../common/myactivate/emptyThread";
+
 import MyThreadItem from "./MyThreadItem";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
@@ -30,6 +32,9 @@ const MyThreadBody = () => {
   const { listedThreadsAndComments, isPending } = useListedThreadsAndComments(id);
   if (isPending) {
     return <div>loading...</div>;
+  }
+  if (listedThreadsAndComments.length === 0) {
+    return <EmptyThread type="thread" />;
   }
 
   return (

--- a/src/components/common/myactivate/emptyThread.tsx
+++ b/src/components/common/myactivate/emptyThread.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  type: string;
+}
+
+const EmptyThread = ({ type }: Props) => {
+  return (
+    <div className="mt-[-170px] flex h-screen flex-col items-center justify-center">
+      <div className=" text-9xl font-bold text-gray-300">텅...</div>
+      <div className="mt-20 text-4xl font-bold text-gray-300">
+        {type === "notification" ? "아직 알림이 없어요!" : "어서 글을 작성해주세요!"}
+      </div>
+    </div>
+  );
+};
+
+export default EmptyThread;


### PR DESCRIPTION
## 📝 작업 내용

빈 리스트 시 사용자가 알 수 있도록 문구를 표기합니다.
기존에 내 알림에서 어떤 채널에서 댓글이 달리고 멘션이 되었는지 채널이 제대로 매칭되지 않아 수정하였습니다.

### 📷 스크린샷 (선택)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/91151775/5e08fd02-ac65-4c9b-a0c7-a95ad4150bc7)

close #108 
