### PR TITLE
[#118] Feat: use toast hook 구현 및 좋아요 클릭시 토스트 적용

### DIFF
--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -14,6 +14,9 @@ import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 import useDeleteThreadLike from "@/apis/thread/useDeleteThreadLike";
 import useDeleteThread from "@/apis/thread/useDeleteThread";
 import useLikeThread from "@/hooks/api/useLikeThread";
+import useToast from "@/hooks/common/useToast";
+import LoginModal from "@/components/Layout/Modals/Login";
+import RegisterModal from "@/components/Layout/Modals/Register";
 
 interface Props {
   thread: Thread;
@@ -30,6 +33,9 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
   const [hoveredListId, setHoveredListId] = useState<string | null>(null);
   const likedByUser = likes.find((like) => like.user === user?._id);
   const isAlreadyLikedByUser = !!likedByUser;
+  const { showToast } = useToast();
+  const [isLoginModalOpen, setLoginModalOpen] = useState(false);
+  const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
 
   const { mutate: deleteThread } = useDeleteThread(channelId);
 
@@ -43,6 +49,17 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
 
   const handleClickLikeButton = (event: MouseEvent) => {
     event.stopPropagation();
+
+    if (!user) {
+      showToast({
+        message: "로그인 한 유저만 좋아요가 가능합니다.",
+        actionLabel: "로그인",
+        onActionClick: () => setLoginModalOpen(true),
+        duration: 2000,
+      });
+
+      return;
+    }
 
     if (isAlreadyLikedByUser) removeLike(likedByUser._id);
     else likeAndNotify({ threadId: id, authorId: author._id });
@@ -60,9 +77,8 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
       onMouseLeave={handleMouseLeave}
       className="relative cursor-pointer px-2.5 py-5 hover:bg-gray-100"
       tabIndex={0}
-      onClick={onClick}
     >
-      <div className="flex items-center">
+      <div className="flex items-center" onClick={onClick}>
         <Avatar className="mr-3">
           <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
           <AvatarFallback>{author.nickname.charAt(0)}</AvatarFallback>
@@ -95,10 +111,24 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             authorId={author._id}
             onDelete={handleClickDeleteButton}
             handleClickLikeButton={handleClickLikeButton}
-            className="absolute -top-6 right-6 z-10"
+            className="absolute -top-6 right-6"
           />
         )}
       </div>
+      {!user && (
+        <LoginModal
+          open={isLoginModalOpen}
+          toggleOpen={setLoginModalOpen}
+          openRegisterModal={setRegisterModalOpen}
+        />
+      )}
+      {!user && (
+        <RegisterModal
+          open={isRegisterModalOpen}
+          toggleOpen={setRegisterModalOpen}
+          openLoginModal={setLoginModalOpen}
+        />
+      )}
     </li>
   );
 };

--- a/src/components/common/thread/ThreadToolbar.tsx
+++ b/src/components/common/thread/ThreadToolbar.tsx
@@ -4,6 +4,7 @@ import { MouseEvent, useState } from "react";
 import ThreadTooltip from "./ThreadTooltip";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
+import { cn } from "@/lib/utils";
 
 interface Props {
   authorId: string;
@@ -26,7 +27,10 @@ const ThreadToolbar = ({ authorId, handleClickLikeButton, onDelete, className }:
 
   return (
     <section
-      className={`flex items-center justify-between rounded-md border border-gray-300 bg-white ${className}`}
+      className={cn(
+        "flex items-center justify-between rounded-md border border-gray-300 bg-white",
+        className,
+      )}
     >
       <button
         className="relative p-2 hover:bg-gray-100"

--- a/src/hooks/common/useToast.ts
+++ b/src/hooks/common/useToast.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios";
 import { toast } from "sonner";
 
 interface ToastParameters {
@@ -5,6 +6,15 @@ interface ToastParameters {
   duration?: number;
   actionLabel: string;
   onActionClick: () => void;
+}
+
+interface PromiseToastParameters<T> {
+  promise: Promise<T>;
+  messages: {
+    loading: string;
+    success: string | ((data: T) => string);
+    error: string | ((error: AxiosError) => string);
+  };
 }
 
 const useToast = () => {
@@ -20,7 +30,17 @@ const useToast = () => {
     });
   };
 
-  return { showToast };
+  const showPromiseToast = <T>({ promise, messages }: PromiseToastParameters<T>) => {
+    toast.promise(promise, {
+      loading: messages.loading,
+      success: (data) =>
+        typeof messages.success === "function" ? messages.success(data) : messages.success,
+      error: (error) =>
+        typeof messages.error === "function" ? messages.error(error) : messages.error,
+    });
+  };
+
+  return { showToast, showPromiseToast };
 };
 
 export default useToast;

--- a/src/hooks/common/useToast.ts
+++ b/src/hooks/common/useToast.ts
@@ -2,13 +2,13 @@ import { toast } from "sonner";
 
 interface ToastParameters {
   message: string;
-  duration: number;
+  duration?: number;
   actionLabel: string;
   onActionClick: () => void;
 }
 
 const useToast = () => {
-  const showToast = ({ message, duration, actionLabel, onActionClick }: ToastParameters) => {
+  const showToast = ({ message, duration = 2000, actionLabel, onActionClick }: ToastParameters) => {
     toast(message, {
       action: actionLabel
         ? {

--- a/src/hooks/common/useToast.ts
+++ b/src/hooks/common/useToast.ts
@@ -1,0 +1,26 @@
+import { toast } from "sonner";
+
+interface ToastParameters {
+  message: string;
+  duration: number;
+  actionLabel: string;
+  onActionClick: () => void;
+}
+
+const useToast = () => {
+  const showToast = ({ message, duration, actionLabel, onActionClick }: ToastParameters) => {
+    toast(message, {
+      action: actionLabel
+        ? {
+            label: actionLabel,
+            onClick: onActionClick,
+          }
+        : undefined,
+      duration,
+    });
+  };
+
+  return { showToast };
+};
+
+export default useToast;


### PR DESCRIPTION
## 📝 작업 내용

- useToast 훅을 구현
  - showToast와 프로미스 show Toast 함수 구현
- 좋아요 클릭시 토스트 렌더
  - 토스트에서 로그인 클릭시 로그인 모달 띄우도록 구현

## 💬 리뷰 요구사항

- 윤서님께서 toast.promise를 사용하고 계셔서 showPromsieToast도 구현했습니다.
- 간단히 테스트 해봤는데 되는 것 같긴한데 문제가 없는지 봐주시면 감사하겠습니다 : )

close #118 
