### PR TITLE
[#135] Fix: data가 없는 경우 파싱 시도하여 에러 발생 해결 및 데이터 없는 경우 UI 설정

### DIFF
--- a/src/apis/thread/queryFn.ts
+++ b/src/apis/thread/queryFn.ts
@@ -52,6 +52,9 @@ export const deleteThreadLike = (postId: string) =>
 
 export const getThreadByThreadId = async (threadId: string) => {
   const thread = await api.get<Thread>({ url: `/posts/${threadId}` });
+
+  if (!thread) return null;
+
   const { content, nickname } = parseTitleOrComment(thread.title);
 
   return {

--- a/src/components/Home/ThreadList.tsx
+++ b/src/components/Home/ThreadList.tsx
@@ -27,10 +27,7 @@ const ThreadList = ({ threads }: Props) => {
 
   return (
     <div>
-      <ul
-        ref={threadListRef}
-        className="h-[calc(100vh-250px)] overflow-y-auto rounded-sm border border-t-0 pt-80pxr"
-      >
+      <ul ref={threadListRef} className="h-[calc(100vh-250px)] overflow-y-auto pt-80pxr">
         {threads.map((thread) => (
           <ThreadListItem
             key={thread._id}

--- a/src/components/common/myactivate/EmptyThread.tsx
+++ b/src/components/common/myactivate/EmptyThread.tsx
@@ -1,10 +1,15 @@
+import { cn } from "@/lib/utils";
+
 interface Props {
   type: string;
+  className?: string;
 }
 
-const EmptyThread = ({ type }: Props) => {
+const EmptyThread = ({ type, className }: Props) => {
   return (
-    <div className="mt-[-170px] flex h-screen flex-col items-center justify-center">
+    <div
+      className={cn("mt-[-170px] flex h-screen flex-col items-center justify-center", className)}
+    >
       <div className=" text-9xl font-bold text-gray-300">텅...</div>
       <div className="mt-20 text-4xl font-bold text-gray-300">
         {type === "notification" ? "아직 알림이 없어요!" : "어서 글을 작성해주세요!"}

--- a/src/hooks/api/useUserListByDB.ts
+++ b/src/hooks/api/useUserListByDB.ts
@@ -12,6 +12,8 @@ const useUserListByDB = () => {
 
   useEffect(() => {
     if (!db) return;
+    if (!db.title) return;
+
     setUserListByDB(JSON.parse(JSON.parse(db.title).content));
   }, [db]);
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -6,6 +6,7 @@ import ChannelNavigationMenu from "@/components/Home/ChannelNavigationMenu";
 import ThreadList from "@/components/Home/ThreadList";
 import EditorTextArea from "@/components/common/EditorTextArea";
 import ThreadDetailView from "@/components/common/thread/ThreadDetailView";
+import EmptyThread from "@/components/common/myactivate/EmptyThread";
 import { cn } from "@/lib/utils";
 
 const HomePage = () => {
@@ -29,7 +30,12 @@ const HomePage = () => {
           <ChannelNavigationMenu />
         </div>
         <div className="w-full max-w-4xl px-4">
-          <main>{threads && <ThreadList threads={threads} />}</main>
+          <main className="min-h-[calc(100vh-250px)] rounded-sm border border-t-0 border-solid">
+            <div className="flex min-h-[calc(100vh-250px)] items-center justify-center">
+              {!threads && <EmptyThread type="threads" className="h-full w-full" />}
+            </div>
+            {threads && <ThreadList threads={threads} />}
+          </main>
           <EditorTextArea
             isMention={channelName !== "incompetent"}
             nickname={user?.nickname || "익명의 프롱이"}


### PR DESCRIPTION
## 📝 작업 내용

- `useUserListByDB`
db가 falsy한 값이 아니라 title 키가 없이 객체로 오는 경우가 있다.
이때 분기 처리가 없어 JSON.parse 할때 에러 발생
early return으로 title 키가 없는 경우 파싱하지 않도록 수정

- `getThreadByThreadId`
여기서도 thread가 없을때, 파싱 시도를 해서 에러가 난다.
마찬가지로 Early return으로 해결

- `Home Page`
스레드가 하나도 없는 경우 min-height가 없어 네비게이션 탭 바로 아래에 입력창이 위치했다.
min height를 설정하고 재준님의 `EmptyThread` 컴포넌트를 렌더링 했다.
이 과정에서 EmptyThreaad 컴포넌트에 className props를 추가하게 되었다.

### 📷 스크린샷
<img width="1792" alt="스크린샷 2024-01-11 오후 7 05 50" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/f9809a5e-db4c-4f28-af46-d15b7db02060">

## 💬 리뷰 요구사항

재훈님, 재준님의 코드 수정이 들어가게 되어서 한 번 확인해주시면 감사하겠습니다!

close #135 
