### PR TITLE
[#143] Feat: 기존 스레드 수정 시 EditorTextArea 띄우면 x 버튼으로 추가

### DIFF
--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -26,9 +26,10 @@ interface Props {
   isMention: boolean;
   nickname: string;
   editorProps: EditorProps;
+  onClose?: () => void;
 }
 
-const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
+const EditorTextArea = ({ isMention, nickname, editorProps, onClose }: Props) => {
   // TODO: [24/1/10] user는 EditerTextArea를 사용하는 쪽에서 보내주는게 맞다고 생각하지만 빠른 배포를 위해 여기서 불러쓸게요
   const { user, isPending } = useGetUserInfo();
 
@@ -83,13 +84,13 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
   if (isPending) return <div>로딩 중... </div>;
 
   return (
-    <div className="flex w-full flex-col gap-1 ">
+    <div className="relative flex w-full flex-col gap-1">
       {isMention && <MentionInput mentionedList={mentionedList} onChoose={setmentionedList} />}
 
       <form className="relative">
         <Textarea
           placeholder={user ? `내용을 작성해주세요.` : "로그인이 필요합니다."}
-          className="resize-none text-base"
+          className="resize-none overflow-hidden pr-200pxr text-base"
           {...register("content")}
         />
         <div className="absolute bottom-2 right-2 flex items-center gap-2">
@@ -105,15 +106,34 @@ const EditorTextArea = ({ isMention, nickname, editorProps }: Props) => {
             />
             <p className="text-gray-500">익명</p>
           </label>
-          <button
-            onClick={handleSubmit(handleUpload)}
-            className={cn(
-              "flex h-12 w-12 cursor-pointer items-center justify-center rounded-xl text-black",
-              watch("content") ? "bg-green-600" : "",
-            )}
-          >
-            <SendHorizontal className="h-10 w-10 fill-amber-50 stroke-2" />
-          </button>
+          {onClose ? (
+            <div className="flex items-center gap-2 text-white ">
+              <button className="rounded-sm bg-gray-400 p-3" onClick={onClose}>
+                취소
+              </button>
+              <button
+                onClick={handleSubmit(handleUpload)}
+                className={cn(
+                  "rounded-sm p-3",
+                  watch("content")
+                    ? "border border-[#19d23d] bg-[#19d23d]"
+                    : "border border-gray-300 text-black",
+                )}
+              >
+                확인
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleSubmit(handleUpload)}
+              className={cn(
+                "flex h-12 w-12 cursor-pointer items-center justify-center rounded-xl text-black",
+                watch("content") ? "bg-[#19d23d]" : "",
+              )}
+            >
+              <SendHorizontal className="h-10 w-10 fill-amber-50 stroke-2" />
+            </button>
+          )}
         </div>
       </form>
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -19,7 +19,7 @@ const HomePage = () => {
   };
 
   return (
-    <div className="relative overflow-hidden">
+    <div className="relative h-screen overflow-hidden">
       <div
         className={cn(
           "duration-600 mt-12 flex flex-col items-center justify-center transition",


### PR DESCRIPTION
## 📝 작업 내용

- 원래 x 버튼을 띄우려다가 멘션을 취소하느 느낌이 들어서 슬랙과 동일하게 취소, 확인 버튼으로 수정했습니다.
- 에디터에 길게 쓰면 익명 창 넘어까지 글이써져서 px를 줘서 막았습니다. 
- 스크롤도 숨겼어요

## 💬 리뷰 요구사항

- 빠르게빠르게하느라 에디터에 너무 하드 코딩 되었습니다... onClose 유무로 판단하고 있어서 이정도로 분기처리되는게 많으면 에디터 하나로 모든 걸 처리하기보다 합성컴포넌트로 만들거나 createThread, patchThread, commentThread 따로따로 만들어서 사용해야 할 것 같습니다.

close #143
