### PR TITLE
[#138] Style: 내 알림, 내가 작성한 글 페이지에 비어있는 경우 "텅" 글자가 가운데 오도록 스타일 변경

### DIFF
--- a/src/components/MyNotifications/MyNotificationBody.tsx
+++ b/src/components/MyNotifications/MyNotificationBody.tsx
@@ -35,7 +35,7 @@ const MyNotificationBody = () => {
     return <span>Loading...</span>;
   }
   if (listedNotificationAndMention.length === 0) {
-    return <EmptyThread type="notification" />;
+    return <EmptyThread type="notification" className="h-[calc(100vh-7rem)] min-h-[20rem]" />;
   }
 
   return (

--- a/src/components/MyThreads/MyThreadBody.tsx
+++ b/src/components/MyThreads/MyThreadBody.tsx
@@ -34,7 +34,7 @@ const MyThreadBody = () => {
     return <div>loading...</div>;
   }
   if (listedThreadsAndComments.length === 0) {
-    return <EmptyThread type="thread" />;
+    return <EmptyThread type="thread" className="h-[calc(100vh-10.5rem)] min-h-[20rem]" />;
   }
 
   return (


### PR DESCRIPTION
## 📝 작업 내용

- 내 알림과 내가 작성한 글 페이지에 높이가 지정되어있지 않아 가운데이 위치하지 않아 위/아래 패딩과 제목 높이를 가늠해서 지정해주었습니다.
- 브라우저 높이를 줄이면 텅... 문구가 제목을 침범하여 최소 높이를 지정해주었습니다.

### 📷 스크린샷 

![화면 기록 2024-01-12 오전 1 29 29](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/b1c21b26-1c3e-47e4-913d-6b75b9db97a2)


## 💬 리뷰 요구사항

- 편하게 리뷰 주시면 감사하겠습니다 :D

close #138 