### PR TITLE
[#127] Feat: 편집 버튼 클릭시 에디터로 변환

### DIFF
--- a/src/apis/comment/useDeleteComment.ts
+++ b/src/apis/comment/useDeleteComment.ts
@@ -3,10 +3,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteComment } from "@/apis/comment/queryFn.ts";
 import threads from "@/apis/thread/queryKey.ts";
 
-const useDeleteComment = (threadId: string) => {
+const useDeleteComment = (threadId: string | undefined) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  const { mutate, ...props } = useMutation({
     mutationFn: deleteComment,
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -15,6 +15,8 @@ const useDeleteComment = (threadId: string) => {
     },
     onError: () => {},
   });
+
+  return { deleteComment: mutate, ...props };
 };
 
 export default useDeleteComment;

--- a/src/apis/thread/usePutThread.ts
+++ b/src/apis/thread/usePutThread.ts
@@ -1,10 +1,23 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import threads from "./queryKey";
 
 import { patchThread } from "@/apis/thread/queryFn.ts";
 
 const usePutThread = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: patchThread,
+    onSuccess: (threadResponse, parameters) => {
+      queryClient.invalidateQueries({
+        queryKey: threads.threadsByChannel(threadResponse.channel?._id).queryKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadDetail(parameters.postId).queryKey,
+      });
+    },
     onError: () => {},
   });
 };

--- a/src/apis/thread/usePutThread.ts
+++ b/src/apis/thread/usePutThread.ts
@@ -2,9 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import { patchThread } from "@/apis/thread/queryFn.ts";
 
-export const usePutThread = () => {
+const usePutThread = () => {
   return useMutation({
     mutationFn: patchThread,
     onError: () => {},
   });
 };
+
+export default usePutThread;

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -26,10 +26,10 @@ interface Props {
   isMention: boolean;
   nickname: string;
   editorProps: EditorProps;
-  onClose?: () => void;
+  onEditCancel?: () => void;
 }
 
-const EditorTextArea = ({ isMention, nickname, editorProps, onClose }: Props) => {
+const EditorTextArea = ({ isMention, nickname, editorProps, onEditCancel }: Props) => {
   // TODO: [24/1/10] user는 EditerTextArea를 사용하는 쪽에서 보내주는게 맞다고 생각하지만 빠른 배포를 위해 여기서 불러쓸게요
   const { user, isPending } = useGetUserInfo();
 
@@ -112,9 +112,9 @@ const EditorTextArea = ({ isMention, nickname, editorProps, onClose }: Props) =>
             <input type="checkbox" {...register("anonymous")} onClick={handleClickCheckBox} />
             <p className="text-gray-500">익명</p>
           </label>
-          {onClose ? (
+          {onEditCancel ? (
             <div className="flex items-center gap-2 text-white ">
-              <button className="rounded-sm bg-gray-400 p-3" onClick={onClose}>
+              <button className="rounded-sm bg-gray-400 p-3" onClick={onEditCancel}>
                 취소
               </button>
               <button

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -105,7 +105,7 @@ const EditorTextArea = ({
   if (isPending) return <div>로딩 중... </div>;
 
   return (
-    <div className="flex w-full flex-col gap-1 ">
+    <div className="flex w-full flex-col gap-1">
       {isMention && <MentionInput mentionedList={mentionedList} onChoose={setMentionedList} />}
 
       <form className="relative">

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -26,17 +26,10 @@ interface Props {
   isMention: boolean;
   nickname: string;
   editorProps: EditorProps;
-  onEditCancel?: () => void;
-  onEditComplete?: () => void;
+  onEditClose?: () => void;
 }
 
-const EditorTextArea = ({
-  isMention,
-  nickname,
-  editorProps,
-  onEditCancel,
-  onEditComplete,
-}: Props) => {
+const EditorTextArea = ({ isMention, nickname, editorProps, onEditClose }: Props) => {
   // TODO: [24/1/10] user는 EditerTextArea를 사용하는 쪽에서 보내주는게 맞다고 생각하지만 빠른 배포를 위해 여기서 불러쓸게요
   const { user, isPending } = useGetUserInfo();
 
@@ -70,7 +63,7 @@ const EditorTextArea = ({
     upload(formValues);
     setMentionedList([]);
     setValue("content", "");
-    onEditComplete?.();
+    onEditClose?.();
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -120,9 +113,9 @@ const EditorTextArea = ({
             <input type="checkbox" {...register("anonymous")} onClick={handleClickCheckBox} />
             <p className="text-gray-500">익명</p>
           </label>
-          {onEditCancel ? (
+          {onEditClose ? (
             <div className="flex items-center gap-2 text-white ">
-              <button className="rounded-sm bg-gray-400 p-3" onClick={onEditCancel}>
+              <button className="rounded-sm bg-gray-400 p-3" onClick={onEditClose}>
                 취소
               </button>
               <button

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -27,9 +27,10 @@ interface Props {
   nickname: string;
   editorProps: EditorProps;
   onEditClose?: () => void;
+  isAnonymous?: boolean;
 }
 
-const EditorTextArea = ({ isMention, nickname, editorProps, onEditClose }: Props) => {
+const EditorTextArea = ({ isMention, nickname, editorProps, onEditClose ,isAnonymous}: Props) => {
   // TODO: [24/1/10] user는 EditerTextArea를 사용하는 쪽에서 보내주는게 맞다고 생각하지만 빠른 배포를 위해 여기서 불러쓸게요
   const { user, isPending } = useGetUserInfo();
 
@@ -42,7 +43,7 @@ const EditorTextArea = ({ isMention, nickname, editorProps, onEditClose }: Props
   });
 
   const { register, handleSubmit, watch, setValue, getValues } = useForm({
-    defaultValues: { anonymous: true, content: "" },
+    defaultValues: { anonymous: !!isAnonymous, content: "" },
   });
 
   const handleUpload = (formValues: FormValues) => {

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -27,9 +27,16 @@ interface Props {
   nickname: string;
   editorProps: EditorProps;
   onEditCancel?: () => void;
+  onEditComplete?: () => void;
 }
 
-const EditorTextArea = ({ isMention, nickname, editorProps, onEditCancel }: Props) => {
+const EditorTextArea = ({
+  isMention,
+  nickname,
+  editorProps,
+  onEditCancel,
+  onEditComplete,
+}: Props) => {
   // TODO: [24/1/10] user는 EditerTextArea를 사용하는 쪽에서 보내주는게 맞다고 생각하지만 빠른 배포를 위해 여기서 불러쓸게요
   const { user, isPending } = useGetUserInfo();
 
@@ -63,6 +70,7 @@ const EditorTextArea = ({ isMention, nickname, editorProps, onEditCancel }: Prop
     upload(formValues);
     setMentionedList([]);
     setValue("content", "");
+    onEditComplete?.();
   };
 
   const handleKeydown = (event: KeyboardEvent) => {

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -1,3 +1,5 @@
+import { XIcon } from "lucide-react";
+
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 import { formatDate } from "@/utils/formatDate";
@@ -7,18 +9,29 @@ import { Comment } from "@/types/thread";
 
 interface Props {
   commentInfo: Comment;
+  onClose: (commentId: string) => void;
+  isAuthor: boolean;
 }
 
 /**
  * 일관성 유지를 위해 ThreadListItem의 기능을 단순히 제거한 버전으로 스타일의 변경은 없는 코드이다.
  * 컴포넌트 통합 혹은 중복 코드 제거 등의 책임은 ThreadListItem 작성자에게 있다.
  */
-const CommentListItem = ({ commentInfo }: Props) => {
-  const { createdAt, comment } = commentInfo;
+const CommentListItem = ({ commentInfo, onClose, isAuthor }: Props) => {
+  const { createdAt, comment, _id } = commentInfo;
   const { content, nickname, mentionedList } = parseTitleOrComment(comment);
 
+  const handleClick = () => {
+    onClose(_id);
+  };
+
   return (
-    <li className="relative cursor-pointer px-2.5 py-5 hover:bg-gray-100">
+    <li className="relative flex cursor-pointer flex-col gap-1  px-2.5 py-5 hover:bg-gray-100">
+      {isAuthor && (
+        <button onClick={handleClick} className="flex justify-end ">
+          <XIcon className="rounded-sm text-gray-500 hover:bg-gray-600" />
+        </button>
+      )}
       <div className="flex items-center">
         <Avatar className="mr-3">
           <AvatarImage src="/svg/userProfile.svg" alt="프로필" />

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -26,7 +26,7 @@ const CommentListItem = ({ commentInfo, onClose, isAuthor }: Props) => {
   };
 
   return (
-    <li className="relative flex cursor-pointer flex-col gap-1  px-2.5 py-5 hover:bg-gray-100">
+    <li className="relative flex cursor-pointer flex-col gap-1 px-2.5 py-5 hover:bg-gray-100">
       {isAuthor && (
         <button onClick={handleClick} className="flex justify-end ">
           <XIcon className="rounded-sm text-gray-500 hover:bg-gray-600" />

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -8,6 +8,8 @@ import ThreadListItem from "./ThreadListItem";
 
 import { cn } from "@/lib/utils";
 import useGetThread from "@/apis/thread/useGetThread";
+import useGetUserInfo from "@/apis/auth/useGetUserInfo.ts";
+import useDeleteComment from "@/apis/comment/useDeleteComment.ts";
 
 interface Props {
   threadId: string | undefined;
@@ -23,12 +25,18 @@ const channelMap = {
 };
 
 const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
+  const { user } = useGetUserInfo();
   const { thread } = useGetThread(threadId);
+  const { deleteComment } = useDeleteComment(threadId);
 
   if (!thread) return;
 
   const handleClickDetailInner = (event: MouseEvent) => {
     event.stopPropagation();
+  };
+
+  const handleDeleteComment = (commentId: string) => {
+    deleteComment(commentId);
   };
 
   return (
@@ -56,7 +64,12 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
       <div className="max-h-[calc(100vh-400px)] overflow-auto">
         <ol className="flex flex-col gap-4">
           {thread.comments.map((comment) => (
-            <CommentListItem key={comment._id} commentInfo={comment} />
+            <CommentListItem
+              key={comment._id}
+              commentInfo={comment}
+              onClose={handleDeleteComment}
+              isAuthor={comment.author._id === user?._id}
+            />
           ))}
         </ol>
       </div>

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -43,7 +43,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
     <div
       onClick={handleClickDetailInner}
       className={cn(
-        "flex h-screen min-w-500pxr list-none flex-col  overflow-auto border-l border-gray-200 px-4 py-5 shadow-xl",
+        "flex h-screen min-w-500pxr max-w-500pxr list-none flex-col overflow-auto border-l border-gray-200 px-4 py-5 shadow-xl",
         className,
       )}
     >
@@ -61,7 +61,8 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
         <span className="text-gray-500">{thread.comments.length}개의 댓글</span>
         <hr className="flex-1" />
       </div>
-      <div className="max-h-[calc(100vh-400px)] overflow-auto">
+
+      <div className="mb-4">
         <ol className="flex flex-col gap-4">
           {thread.comments.map((comment) => (
             <CommentListItem
@@ -73,7 +74,8 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
           ))}
         </ol>
       </div>
-      <div className="absolute bottom-10 right-0 w-full px-4">
+
+      <div className="w-full pl-2 pr-2">
         <EditorTextArea
           isMention={true}
           nickname={thread.nickname}

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -18,6 +18,7 @@ import useLikeThread from "@/hooks/api/useLikeThread";
 import useToast from "@/hooks/common/useToast";
 import LoginModal from "@/components/Layout/Modals/Login";
 import RegisterModal from "@/components/Layout/Modals/Register";
+import { ANONYMOUS_NICKNAME } from "@/constants/commonConstants.ts";
 
 interface Props {
   thread: Thread;
@@ -148,6 +149,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             nickname={nickname}
             editorProps={{ prevContent: content, postId: id, channelId }}
             onEditClose={handleCloseEditor}
+            isAnonymous={nickname === ANONYMOUS_NICKNAME}
           />
         )}
       </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -87,7 +87,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
       tabIndex={0}
     >
       {editingThreadId !== id && (
-        <div className="flex items-center" onClick={onClick}>
+        <div className="flex" onClick={onClick}>
           <Avatar className="mr-3">
             <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
             <AvatarFallback>{author.nickname.charAt(0)}</AvatarFallback>
@@ -101,10 +101,8 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
                 {formatDate(createdAt)}
               </span>
             </div>
-            <div
-              tabIndex={0}
-              className="mb-10pxr overflow-hidden truncate text-ellipsis pr-50pxr text-gray-500"
-            >
+            <div tabIndex={0} className="mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500">
+              <b>{mentionedList}</b>
               {content}
             </div>
             {likes.length > 0 && (
@@ -124,19 +122,6 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
               />
             )}
           </div>
-          <div
-            tabIndex={0}
-            className="mb-10pxr overflow-hidden truncate text-ellipsis whitespace-pre-wrap pr-50pxr text-gray-500"
-          >
-            <b>{mentionedList}</b> {content}
-          </div>
-          {likes.length > 0 && (
-            <LikeToggleButton
-              clicked={isAlreadyLikedByUser}
-              onClick={handleClickLikeButton}
-              numberOfLikes={likes.length}
-            />
-          )}
         </div>
       )}
 

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -116,7 +116,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
               </span>
             </div>
             <div tabIndex={0} className="mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500">
-              <b>{mentionedList}</b>
+              <b>{`${mentionedList} `}</b>
               {content}
               {createdAt !== updatedAt && <i>(편집됨)</i>}
             </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -116,7 +116,8 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
               </span>
             </div>
             <div tabIndex={0} className="mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500">
-              <b>{`${mentionedList} `}</b>
+              <b>{mentionedList && `${mentionedList} `}</b>
+
               {content}
               {createdAt !== updatedAt && <i>(편집됨)</i>}
             </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -138,7 +138,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
           <EditorTextArea
             isMention={channel.name !== "incompetent"}
             nickname={nickname}
-            editorProps={{ prevContent: content, postId: id }}
+            editorProps={{ prevContent: content, postId: id, channelId }}
             onEditCancel={handleClickCancelEditButton}
             onEditComplete={handleClickSaveEditButton}
           />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -149,7 +149,11 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
           <EditorTextArea
             isMention={channel.name !== "incompetent"}
             nickname={nickname}
-            editorProps={{ prevContent: content, postId: id, channelId }}
+            editorProps={{
+              prevContent: mentionedList ? mentionedList + content : content,
+              postId: id,
+              channelId,
+            }}
             onEditCancel={handleClickCancelEditButton}
             onEditComplete={handleClickSaveEditButton}
           />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -78,6 +78,14 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
     setEditingThreadId(threadId);
   };
 
+  const handleClickCancelEditButton = () => {
+    setEditingThreadId(null);
+  };
+
+  const handleClickSaveEditButton = () => {
+    setEditingThreadId(null);
+  };
+
   return (
     <li
       key={id}
@@ -131,6 +139,8 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             isMention={channel.name !== "incompetent"}
             nickname={nickname}
             editorProps={{ prevContent: content, postId: id }}
+            onEditCancel={handleClickCancelEditButton}
+            onEditComplete={handleClickSaveEditButton}
           />
         )}
       </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -26,7 +26,17 @@ interface Props {
 }
 
 const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
-  const { _id: id, content, author, createdAt, likes, mentionedList, channel, nickname } = thread;
+  const {
+    _id: id,
+    content,
+    author,
+    createdAt,
+    updatedAt,
+    likes,
+    mentionedList,
+    channel,
+    nickname,
+  } = thread;
 
   const { user } = useGetUserInfo();
   const { mutate: deleteThread } = useDeleteThread(channelId);
@@ -112,6 +122,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             <div tabIndex={0} className="mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500">
               <b>{mentionedList}</b>
               {content}
+              {createdAt !== updatedAt && <i>(편집됨)</i>}
             </div>
             {likes.length > 0 && (
               <LikeToggleButton

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -7,6 +7,7 @@ import { formatDate } from "@/utils/formatDate";
 import { Thread } from "@/types/thread";
 
 import LikeToggleButton from "../LikeToggleButton";
+import EditorTextArea from "../EditorTextArea";
 
 import ThreadToolbar from "./ThreadToolbar";
 
@@ -25,19 +26,20 @@ interface Props {
 }
 
 const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
-  const { _id: id, content, author, createdAt, likes, mentionedList } = thread;
+  const { _id: id, content, author, createdAt, likes, mentionedList, channel, nickname } = thread;
 
   const { user } = useGetUserInfo();
+  const { mutate: deleteThread } = useDeleteThread(channelId);
   const { likeAndNotify } = useLikeThread(channelId);
   const { removeLike } = useDeleteThreadLike(channelId);
+
+  const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
   const [hoveredListId, setHoveredListId] = useState<string | null>(null);
   const likedByUser = likes.find((like) => like.user === user?._id);
   const isAlreadyLikedByUser = !!likedByUser;
   const { showToast } = useToast();
   const [isLoginModalOpen, setLoginModalOpen] = useState(false);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
-
-  const { mutate: deleteThread } = useDeleteThread(channelId);
 
   const handleMouseEnter = () => {
     setHoveredListId(id);
@@ -70,6 +72,12 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
     deleteThread(id);
   };
 
+  const handleClickEditButton = (threadId: string) => (event: MouseEvent) => {
+    event.stopPropagation();
+
+    setEditingThreadId(threadId);
+  };
+
   return (
     <li
       key={id}
@@ -78,19 +86,43 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
       className="relative cursor-pointer px-2.5 py-5 hover:bg-gray-100"
       tabIndex={0}
     >
-      <div className="flex" onClick={onClick}>
-        <Avatar className="mr-3">
-          <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
-          <AvatarFallback>{author.nickname.charAt(0)}</AvatarFallback>
-        </Avatar>
-        <div className="min-w-0 flex-grow">
-          <div className="flex justify-between">
-            <span tabIndex={0} className="text-lg font-semibold">
-              {author.nickname}
-            </span>
-            <span tabIndex={0} className="text-gray-400">
-              {formatDate(createdAt)}
-            </span>
+      {editingThreadId !== id && (
+        <div className="flex items-center" onClick={onClick}>
+          <Avatar className="mr-3">
+            <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
+            <AvatarFallback>{author.nickname.charAt(0)}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-grow">
+            <div className="flex justify-between">
+              <span tabIndex={0} className="text-lg font-semibold">
+                {author.nickname}
+              </span>
+              <span tabIndex={0} className="text-gray-400">
+                {formatDate(createdAt)}
+              </span>
+            </div>
+            <div
+              tabIndex={0}
+              className="mb-10pxr overflow-hidden truncate text-ellipsis pr-50pxr text-gray-500"
+            >
+              {content}
+            </div>
+            {likes.length > 0 && (
+              <LikeToggleButton
+                clicked={isAlreadyLikedByUser}
+                onClick={handleClickLikeButton}
+                numberOfLikes={likes.length}
+              />
+            )}
+            {hoveredListId === id && (
+              <ThreadToolbar
+                authorId={author._id}
+                onDelete={handleClickDeleteButton}
+                handleClickLikeButton={handleClickLikeButton}
+                handleClickEditButton={handleClickEditButton(id)}
+                className="absolute -top-6 right-6 z-10"
+              />
+            )}
           </div>
           <div
             tabIndex={0}
@@ -106,12 +138,14 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             />
           )}
         </div>
-        {hoveredListId === id && (
-          <ThreadToolbar
-            authorId={author._id}
-            onDelete={handleClickDeleteButton}
-            handleClickLikeButton={handleClickLikeButton}
-            className="absolute -top-6 right-6"
+      )}
+
+      <div>
+        {editingThreadId === id && (
+          <EditorTextArea
+            isMention={channel.name !== "incompetent"}
+            nickname={nickname}
+            editorProps={{ prevContent: content, postId: id }}
           />
         )}
       </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -149,7 +149,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             nickname={nickname}
             editorProps={{ prevContent: content, postId: id, channelId }}
             onEditClose={handleCloseEditor}
-            isAnonymous={nickname === ANONYMOUS_NICKNAME}
+            isAnonymous={author.nickname === ANONYMOUS_NICKNAME}
           />
         )}
       </div>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -88,11 +88,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
     setEditingThreadId(threadId);
   };
 
-  const handleClickCancelEditButton = () => {
-    setEditingThreadId(null);
-  };
-
-  const handleClickSaveEditButton = () => {
+  const handleCloseEditor = () => {
     setEditingThreadId(null);
   };
 
@@ -149,13 +145,8 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
           <EditorTextArea
             isMention={channel.name !== "incompetent"}
             nickname={nickname}
-            editorProps={{
-              prevContent: mentionedList ? mentionedList + content : content,
-              postId: id,
-              channelId,
-            }}
-            onEditCancel={handleClickCancelEditButton}
-            onEditComplete={handleClickSaveEditButton}
+            editorProps={{ prevContent: content, postId: id, channelId }}
+            onEditClose={handleCloseEditor}
           />
         )}
       </div>

--- a/src/components/common/thread/ThreadToolbar.tsx
+++ b/src/components/common/thread/ThreadToolbar.tsx
@@ -9,11 +9,18 @@ import { cn } from "@/lib/utils";
 interface Props {
   authorId: string;
   handleClickLikeButton: (event: MouseEvent) => void;
+  handleClickEditButton: (event: MouseEvent) => void;
   className?: string;
   onDelete: (event: MouseEvent) => void;
 }
 
-const ThreadToolbar = ({ authorId, handleClickLikeButton, onDelete, className }: Props) => {
+const ThreadToolbar = ({
+  authorId,
+  handleClickLikeButton,
+  handleClickEditButton,
+  onDelete,
+  className,
+}: Props) => {
   const { user } = useGetUserInfo();
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
 
@@ -68,6 +75,7 @@ const ThreadToolbar = ({ authorId, handleClickLikeButton, onDelete, className }:
             aria-label="편집"
             onMouseEnter={handleMouseEnter("edit")}
             onMouseLeave={handleMouseLeave}
+            onClick={handleClickEditButton}
           >
             <PencilLine strokeWidth={1} />
             {hoveredButton === "edit" && (

--- a/src/hooks/api/useChangeThread.ts
+++ b/src/hooks/api/useChangeThread.ts
@@ -7,9 +7,10 @@ import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
 interface Props {
   nickname: string | undefined;
   postId: string;
+  channelId: string;
   mentionedList?: UserDBProps[];
 }
-const useChangeThread = ({ nickname, postId, mentionedList }: Props) => {
+const useChangeThread = ({ nickname, postId, channelId, mentionedList }: Props) => {
   const { mutateAsync: patchThreadMutate } = usePutThread();
   const { mentionNotification } = useMentionNotification({ mentionedList });
   const changeThread = async (formValues: FormValues) => {
@@ -19,10 +20,14 @@ const useChangeThread = ({ nickname, postId, mentionedList }: Props) => {
       title: formJSONStringify({ formValues, nickname, mentionedList }),
       image: null,
       postId,
+      channelId,
     };
+
+    console.log("threadRequest", threadRequest);
 
     const ThreadResponse = await patchThreadMutate(threadRequest);
 
+    console.log("ThreadResponse", ThreadResponse);
     if (!mentionedList) return;
 
     mentionNotification({

--- a/src/hooks/api/useChangeThread.ts
+++ b/src/hooks/api/useChangeThread.ts
@@ -23,11 +23,8 @@ const useChangeThread = ({ nickname, postId, channelId, mentionedList }: Props) 
       channelId,
     };
 
-    console.log("threadRequest", threadRequest);
-
     const ThreadResponse = await patchThreadMutate(threadRequest);
 
-    console.log("ThreadResponse", ThreadResponse);
     if (!mentionedList) return;
 
     mentionNotification({

--- a/src/hooks/api/useChangeThread.ts
+++ b/src/hooks/api/useChangeThread.ts
@@ -1,4 +1,4 @@
-import { usePutThread } from "@/apis/thread/usePutThread.ts";
+import usePutThread from "@/apis/thread/usePutThread.ts";
 import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -69,11 +69,11 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
   });
 
   useEffect(() => {
-    if (isCreateThreadProps(editorProps)) {
-      setUpload(() => uploadThread);
-    }
     if (isPatchThreadProps(editorProps)) {
       setUpload(() => changeThread);
+    }
+    if (isCreateThreadProps(editorProps)) {
+      setUpload(() => uploadThread);
     }
     if (isCommentProps(editorProps)) {
       setUpload(() => uploadComment);

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -69,11 +69,11 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
   });
 
   useEffect(() => {
-    if (isPatchThreadProps(editorProps)) {
-      setUpload(() => changeThread);
-    }
     if (isCreateThreadProps(editorProps)) {
       setUpload(() => uploadThread);
+    }
+    if (isPatchThreadProps(editorProps)) {
+      setUpload(() => changeThread);
     }
     if (isCommentProps(editorProps)) {
       setUpload(() => uploadComment);

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -12,6 +12,7 @@ interface CreateThreadProps {
 interface PatchThreadProps {
   prevContent: string;
   postId: string;
+  channelId: string;
 }
 
 interface CommentProps {
@@ -51,11 +52,14 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
     channelId: isCreateThreadProps(editorProps) ? editorProps.channelId : "",
     mentionedList,
   });
+
   const { changeThread } = useChangeThread({
     nickname,
     postId: isPatchThreadProps(editorProps) ? editorProps.postId : "",
+    channelId: isPatchThreadProps(editorProps) ? editorProps.channelId : "",
     mentionedList,
   });
+
   const { uploadComment } = useUploadComment({
     nickname,
     postId: isCommentProps(editorProps) ? editorProps.postId : "",

--- a/src/hooks/api/useUpdateUserList.ts
+++ b/src/hooks/api/useUpdateUserList.ts
@@ -7,11 +7,14 @@ import useRegister from "@/apis/auth/useRegister.ts";
 
 const useUpdateUserList = () => {
   const { mutateAsync, isError, isSuccess, error } = useRegister();
+
   const { changeThread } = useChangeThread({
     nickname: "데브코스 관리자",
     postId: import.meta.env.VITE_ADMIN_DB,
+    channelId: import.meta.env.VITE_ADMIN_CHANNEL,
   });
-  const { login } = usePostLogin({ toggleOpen: () => { } });
+
+  const { login } = usePostLogin({ toggleOpen: () => {} });
   const { userListByDB } = useUserListByDB();
   const { mutate: logoutMutate } = usePostLogout();
 


### PR DESCRIPTION
## 📝 작업 내용

- 편집 버튼 클릭시 해당 리스트만 에디터로 변환
- 편집 취소, 편집 저장하면 에디터에서 리스트로 변환하기 위한 set함수를 `EditorTextArea` 컴포넌트에 props로 전달
- usePutThread 성공시 쿼리키 invalidate

## 💬 리뷰 요구사항

편집 저장시, 변경된 내용이 저장이 안되고 리스트가 삭제되고 있습니다...
이슈 처리 도와주십쇼

close #127 
