### PR TITLE
[154] Fix: 삭제된 댓글에 대하여 파싱에러 해결

### DIFF
--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -19,7 +19,7 @@ const theme = "light";
 const Sidebar = () => {
   const { pathname } = useLocation();
   const userInfo = useGetUserInfo();
-
+  console.log(userInfo.user);
   if (userInfo.user) {
     const hasNewNotification = userInfo.user.notifications.length > 0 ? true : false;
 

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -19,7 +19,6 @@ const theme = "light";
 const Sidebar = () => {
   const { pathname } = useLocation();
   const userInfo = useGetUserInfo();
-  console.log(userInfo.user);
   if (userInfo.user) {
     const hasNewNotification = userInfo.user.notifications.length > 0 ? true : false;
 

--- a/src/components/MyNotifications/CommentNotification.tsx
+++ b/src/components/MyNotifications/CommentNotification.tsx
@@ -9,8 +9,12 @@ interface Props {
 }
 const CommentNotification = ({ postId, comment, createdAt }: Props) => {
   const createdDate = formatDate(createdAt);
-  const { content } = JSON.parse(comment);
-
+  let content = "";
+  try {
+    content = JSON.parse(comment).content;
+  } catch (e) {
+    content = "댓글이 삭제되었습니다.";
+  }
   return <MyNotificationContent content={content} createdDate={createdDate} postId={postId} />;
 };
 export default CommentNotification;


### PR DESCRIPTION
## 📝 작업 내용

댓글 삭제 시 내 알림에서 파싱에러가 발생하여 try catch문으로 해결했습니다.


close #154 
