### PR TITLE
[#158] Feat: 스레드 리스트 아래에 댓글 개수 표시

### DIFF
--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -25,7 +25,7 @@ const Sidebar = () => {
     return (
       <SidebarView
         pathname={pathname}
-        user={user}
+        user={{ nickname: userInfo.user.nickname, profileImgUrl: userInfo.user.image }}
         hasNewNotification={hasNewNotification}
         theme={theme}
       />

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -50,7 +50,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
       <div className="flex items-center justify-between p-2">
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-bold text-gray-700">스레드</h2>
-          <p className="text-sm text-muted-foreground">#{channelMap[thread.channel.name]}게시판</p>
+          <p className="text-sm text-muted-foreground">#{channelMap[thread.channel?.name]}게시판</p>
         </div>
         <button onClick={onClose}>
           <XIcon className="text-gray-500" />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -38,6 +38,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
     mentionedList,
     channel,
     nickname,
+    comments,
   } = thread;
 
   const { user } = useGetUserInfo();
@@ -52,6 +53,7 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
   const { showToast } = useToast();
   const [isLoginModalOpen, setLoginModalOpen] = useState(false);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
+  console.log(comments);
 
   const handleMouseEnter = () => {
     setHoveredListId(id);
@@ -123,19 +125,30 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
                 {formatDate(createdAt)}
               </span>
             </div>
-            <div tabIndex={0} className="mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500">
+            <div
+              tabIndex={0}
+              className="mb-10pxr line-clamp-3 truncate whitespace-pre-wrap pr-50pxr text-gray-500"
+            >
               <b>{mentionedList && `${mentionedList} `}</b>
 
               {content}
               {createdAt !== updatedAt && <i>(편집됨)</i>}
             </div>
-            {likes.length > 0 && (
-              <LikeToggleButton
-                clicked={isAlreadyLikedByUser}
-                onClick={handleClickLikeButton}
-                numberOfLikes={likes.length}
-              />
-            )}
+            <div className="flex items-center justify-start gap-2">
+              {likes.length > 0 && (
+                <LikeToggleButton
+                  clicked={isAlreadyLikedByUser}
+                  onClick={handleClickLikeButton}
+                  numberOfLikes={likes.length}
+                />
+              )}
+
+              {comments.length > 0 && (
+                <div className="mb-10pxr mt-2 w-11/12 text-sm font-bold text-blue-500">
+                  {comments.length} 개의 댓글
+                </div>
+              )}
+            </div>
             {hoveredListId === id && (
               <ThreadToolbar
                 authorId={author._id}

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -33,7 +33,6 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
     content,
     author,
     createdAt,
-    updatedAt,
     likes,
     mentionedList,
     channel,


### PR DESCRIPTION
## 📝 작업 내용

- 스레드 리스트 아래에 댓글 개수 표시
- 게시판에서 보이는 스레드 줄 수 제한 (3줄)
- 스레드 상세보기에서 thread.channel이 undefined인 경우 처리

### 📷 스크린샷
<img width="875" alt="스크린샷 2024-01-12 오전 11 59 31" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/c5544d71-6fcf-48f9-921d-8effd07c754c">

## 💬 리뷰 요구사항
UI 갠춘한가요?

close #158
