### PR TITLE
[#170] Fix 스레드 상세보기는 말줄임 없도록 수정

### DIFF
--- a/src/apis/thread/queryFn.ts
+++ b/src/apis/thread/queryFn.ts
@@ -25,10 +25,12 @@ export const patchThread = async (postInfo: PatchThread) => {
   return await api.put<Thread>({ url: `/posts/update`, data: postInfo });
 };
 
-export const getThreadsByChannelId = async (channelId: string) => {
-  const threads = await api.get<Thread[]>({ url: `/posts/channel/${channelId}` });
-
-  return threads.map((thread) => {
+export const getThreadsByChannelId = async (channelId: string, pageParam: number) => {
+  const response = await api.get<Thread[]>({
+    url: `/posts/channel/${channelId}`,
+    params: { offset: pageParam, limit: 6 },
+  });
+  const threads = response.map((thread) => {
     const { name } = parseFullName(thread.author.fullName);
     const { content, nickname, mentionedList } = parseTitleOrComment(thread.title);
 
@@ -36,6 +38,7 @@ export const getThreadsByChannelId = async (channelId: string) => {
       ...thread,
       content,
       mentionedList,
+      nextPage: pageParam,
       author: {
         ...thread.author,
         name,
@@ -43,6 +46,8 @@ export const getThreadsByChannelId = async (channelId: string) => {
       },
     };
   });
+
+  return threads;
 };
 
 export const postThreadLike = (threadId: string) =>

--- a/src/apis/thread/queryKey.ts
+++ b/src/apis/thread/queryKey.ts
@@ -9,7 +9,9 @@ import { getThreadByThreadId, getThreadsByChannelId } from "./queryFn";
 const threads = createQueryKeys("thread", {
   threadsByChannel: (channelId: string | undefined) => ({
     queryKey: ["threads", channelId],
-    queryFn: channelId ? () => getThreadsByChannelId(channelId) : undefined,
+    queryFn: channelId
+      ? ({ pageParam = 0 }: { pageParam: number }) => getThreadsByChannelId(channelId, pageParam)
+      : undefined,
     enabled: !!channelId,
     select: (threads: Thread[]) =>
       threads.map((thread) => {

--- a/src/components/Home/ThreadList.tsx
+++ b/src/components/Home/ThreadList.tsx
@@ -1,36 +1,38 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import useSelectedThreadStore from "@/stores/thread";
 
 import { Thread } from "@/types/thread";
 
 import ThreadListItem from "@/components/common/thread/ThreadListItem";
+import useIntersectionObserver from "@/hooks/common/useIntersectionObserver";
 
 interface Props {
   threads: Thread[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
 }
 
-const ThreadList = ({ threads }: Props) => {
-  const threadListRef = useRef<HTMLUListElement>(null);
+const ThreadList = ({ threads, hasNextPage, isFetchingNextPage, fetchNextPage }: Props) => {
+  const threadListItemRef = useRef(null);
 
+  const handleIntersect = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
   const { selectThreadId } = useSelectedThreadStore((state) => state);
 
   const handleClickThread = (threadId: string) => () => {
     selectThreadId(threadId);
   };
 
-  useEffect(() => {
-    if (threadListRef.current && threads.length > 0) {
-      threadListRef.current.scrollTop = threadListRef.current.scrollHeight;
-    }
-  }, [threads.length]);
+  useIntersectionObserver({ target: threadListItemRef, handleIntersect });
 
   return (
     <div>
-      <ul
-        ref={threadListRef}
-        className="flex h-[calc(100vh-250px)] flex-col overflow-y-auto pt-80pxr"
-      >
+      <ul className="flex h-[calc(100vh-250px)] flex-col overflow-auto pt-80pxr">
         {threads.map((thread) => (
           <ThreadListItem
             key={thread._id}
@@ -39,6 +41,7 @@ const ThreadList = ({ threads }: Props) => {
             onClick={handleClickThread(thread._id)}
           />
         ))}
+        <div ref={threadListItemRef}></div>
       </ul>
     </div>
   );

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -56,7 +56,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
           <XIcon className="text-gray-500" />
         </button>
       </div>
-      <ThreadListItem thread={thread} channelId={thread.channel._id} />
+      <ThreadListItem thread={thread} channelId={thread.channel._id} isThreadDetail={true} />
       <div className="mx-2 flex items-center gap-2">
         <span className="text-gray-500">{thread.comments.length}개의 댓글</span>
         <hr className="flex-1" />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -52,7 +52,6 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
   const { showToast } = useToast();
   const [isLoginModalOpen, setLoginModalOpen] = useState(false);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
-  console.log(comments);
 
   const handleMouseEnter = () => {
     setHoveredListId(id);

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -20,14 +20,16 @@ import useToast from "@/hooks/common/useToast";
 import LoginModal from "@/components/Layout/Modals/Login";
 import RegisterModal from "@/components/Layout/Modals/Register";
 import { ANONYMOUS_NICKNAME } from "@/constants/commonConstants.ts";
+import { cn } from "@/lib/utils";
 
 interface Props {
   thread: Thread;
   channelId: string;
+  isThreadDetail?: boolean;
   onClick?: (event: MouseEvent) => void;
 }
 
-const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
+const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) => {
   const {
     _id: id,
     content,
@@ -125,7 +127,9 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             </div>
             <div
               tabIndex={0}
-              className="mb-10pxr line-clamp-3 truncate whitespace-pre-wrap pr-50pxr text-gray-500"
+              className={cn("mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500", {
+                "line-clamp-3 truncate": !isThreadDetail,
+              })}
             >
               <b>{mentionedList && `${mentionedList} `}</b>
               {content}

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -1,6 +1,7 @@
 import { RefObject, useEffect, useRef } from "react";
 
 interface Props {
+  target: RefObject<Element>;
   handleIntersect: (element: Element) => void;
   options?: IntersectionObserverInit;
 }
@@ -12,14 +13,14 @@ const defaultOptions = {
 };
 
 const useIntersectionObserver = ({
+  target,
   handleIntersect,
   options = defaultOptions,
-}: Props): RefObject<Element> => {
+}: Props): RefObject<IntersectionObserver | null> => {
   const observerRef = useRef<IntersectionObserver | null>(null);
-  const targetRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!targetRef.current) return;
+    if (!target.current) return;
 
     observerRef.current = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
@@ -29,14 +30,14 @@ const useIntersectionObserver = ({
       });
     }, options);
 
-    observerRef.current.observe(targetRef.current);
+    observerRef.current.observe(target.current);
 
     return () => {
       observerRef.current?.disconnect();
     };
-  }, [handleIntersect, options]);
+  }, [target, handleIntersect, options]);
 
-  return targetRef;
+  return observerRef;
 };
 
 export default useIntersectionObserver;

--- a/src/hooks/common/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver.ts
@@ -1,0 +1,42 @@
+import { RefObject, useEffect, useRef } from "react";
+
+interface Props {
+  handleIntersect: (element: Element) => void;
+  options?: IntersectionObserverInit;
+}
+
+const defaultOptions = {
+  root: null,
+  rootMargin: "10px",
+  threshold: 0.1,
+};
+
+const useIntersectionObserver = ({
+  handleIntersect,
+  options = defaultOptions,
+}: Props): RefObject<Element> => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+
+    observerRef.current = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          handleIntersect(entry.target);
+        }
+      });
+    }, options);
+
+    observerRef.current.observe(targetRef.current);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [handleIntersect, options]);
+
+  return targetRef;
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## 📝 작업 내용

스레드 상세보기와 스레드 리스트가 같은 컴포넌트를 사용합니다.
props로 상세보기인지 판별하는 변수를 받아 상세보기일 경우는 말줄임을 삭제합니다.

### 📷 스크린샷
<img width="1792" alt="스크린샷 2024-01-13 오전 1 35 16" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/9d0c8bdb-2dbd-432b-97c7-1f6980b3ad36">

## 💬 리뷰 요구사항

더 좋은 방법이 있다면 알려주십쇼!!

close #170 
