### PR TITLE
[#170] Fix: 스레드 상세보기에서 말줄임 제거

### DIFF
--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -56,7 +56,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
           <XIcon className="text-gray-500" />
         </button>
       </div>
-      <ThreadListItem thread={thread} channelId={thread.channel._id} />
+      <ThreadListItem thread={thread} channelId={thread.channel._id} isThreadDetail={true} />
       <div className="mx-2 flex items-center gap-2">
         <span className="text-gray-500">{thread.comments.length}개의 댓글</span>
         <hr className="flex-1" />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -54,7 +54,6 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
   const { showToast } = useToast();
   const [isLoginModalOpen, setLoginModalOpen] = useState(false);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
-  console.log(comments);
 
   const handleMouseEnter = () => {
     setHoveredListId(id);

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -20,14 +20,16 @@ import useToast from "@/hooks/common/useToast";
 import LoginModal from "@/components/Layout/Modals/Login";
 import RegisterModal from "@/components/Layout/Modals/Register";
 import { ANONYMOUS_NICKNAME } from "@/constants/commonConstants.ts";
+import { cn } from "@/lib/utils";
 
 interface Props {
   thread: Thread;
   channelId: string;
+  isThreadDetail?: boolean;
   onClick?: (event: MouseEvent) => void;
 }
 
-const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
+const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) => {
   const {
     _id: id,
     content,
@@ -126,7 +128,9 @@ const ThreadListItem = ({ thread, channelId, onClick }: Props) => {
             </div>
             <div
               tabIndex={0}
-              className="mb-10pxr line-clamp-3 truncate whitespace-pre-wrap pr-50pxr text-gray-500"
+              className={cn("mb-10pxr whitespace-pre-wrap pr-50pxr text-gray-500", {
+                "line-clamp-3 truncate": !isThreadDetail,
+              })}
             >
               <b>{mentionedList && `${mentionedList} `}</b>
               {content}


### PR DESCRIPTION
## 📝 작업 내용

스레드 상세보기와 스레드 리스트가 같은 컴포넌트를 사용합니다.
props로 상세보기인지 판별하는 변수를 받아 상세보기일 경우는 말줄임을 삭제합니다.

### 📷 스크린샷
<img width="1792" alt="스크린샷 2024-01-13 오전 1 35 16" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/9d0c8bdb-2dbd-432b-97c7-1f6980b3ad36">

## 💬 리뷰 요구사항

더 좋은 방법이 있다면 알려주십쇼!!

close #170 
