### PR TITLE
[#98] Feat: 프로필 사진 변경 기능 구현

### DIFF
--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -34,5 +34,9 @@ export const putUserInfo = (userInfo: string) =>
 export const putUserPassword = (password: string) =>
   api.put<string>({ url: "/settings/update-password", data: { password } });
 
-export const postUserProfileImage = (image: string) =>
-  api.post<User>({ url: "/users/upload-photo", data: { isCover: false, image } });
+export const postProfileImage = (formData: FormData) =>
+  api.post<User>({
+    url: "/users/upload-photo",
+    data: formData,
+    headers: { "Content-Type": "multipart/form-data" },
+  });

--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -37,7 +37,7 @@ export const putUserPassword = (password: string) =>
 export const postProfileImage = (image: File) => {
   const formData = new FormData();
   formData.append("isCover", JSON.stringify(false));
-  formData.append("profileImage", image);
+  formData.append("image", image);
 
   return api.post<User>({
     url: "/users/upload-photo",

--- a/src/apis/auth/queryFn.ts
+++ b/src/apis/auth/queryFn.ts
@@ -34,9 +34,14 @@ export const putUserInfo = (userInfo: string) =>
 export const putUserPassword = (password: string) =>
   api.put<string>({ url: "/settings/update-password", data: { password } });
 
-export const postProfileImage = (formData: FormData) =>
-  api.post<User>({
+export const postProfileImage = (image: File) => {
+  const formData = new FormData();
+  formData.append("isCover", JSON.stringify(false));
+  formData.append("profileImage", image);
+
+  return api.post<User>({
     url: "/users/upload-photo",
     data: formData,
     headers: { "Content-Type": "multipart/form-data" },
   });
+};

--- a/src/apis/auth/usePutProfile.ts
+++ b/src/apis/auth/usePutProfile.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { getLocalStorage } from "@/utils/localStorage";
 
-import { postUserProfileImage, putUserInfo, putUserPassword } from "./queryFn";
+import { postProfileImage, putUserInfo, putUserPassword } from "./queryFn";
 import auth from "./queryKey";
 
 const usePutProfile = () => {
@@ -22,8 +22,8 @@ const usePutProfile = () => {
     mutationFn: (password: string) => putUserPassword(password),
   });
 
-  const { mutateAsync: updateProfileImage } = useMutation({
-    mutationFn: (image: string) => postUserProfileImage(image),
+  const { mutateAsync: uploadProfileImage } = useMutation({
+    mutationFn: postProfileImage,
   });
 
   const updateAllProfile = async (userInfo: string, password: string) => {
@@ -35,7 +35,7 @@ const usePutProfile = () => {
     updateUserName,
     updatePassword,
     updateAllProfile,
-    updateProfileImage,
+    uploadProfileImage,
   };
 };
 

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,13 +1,18 @@
 import { Image } from "lucide-react";
 import { useRef, useState } from "react";
 import * as Sentry from "@sentry/react";
+import { AxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
 
 import { cn } from "@/lib/utils";
 import usePutProfile from "@/apis/auth/usePutProfile";
 import useToast from "@/hooks/common/useToast";
-import { AUTH_ERROR_MESSAGE, AUTH_SUCCESS_MESSAGE } from "@/constants/toastMessage";
+import {
+  AUTH_ERROR_MESSAGE,
+  AUTH_ERROR_RESPONSE,
+  AUTH_SUCCESS_MESSAGE,
+} from "@/constants/toastMessage";
 
 interface Props {
   profileImage: string | undefined;
@@ -61,7 +66,12 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
           Sentry.captureMessage("ui 사용 - 사용자 프로필 이미지 변경", "info");
           return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
         },
-        error: AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD,
+        error: (error: AxiosError) => {
+          if (error?.response?.data === AUTH_ERROR_RESPONSE.IMAGE_UNMATCHED) {
+            return AUTH_ERROR_MESSAGE.IMAGE_UNMATCHED;
+          }
+          return AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD;
+        },
       },
     });
   };

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -13,6 +13,7 @@ import {
   AUTH_ERROR_RESPONSE,
   AUTH_SUCCESS_MESSAGE,
 } from "@/constants/toastMessage";
+import { DEFAULT_PROFILE } from "@/constants/commonConstants";
 
 interface Props {
   profileImage: string | undefined;
@@ -93,7 +94,7 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
         onDrop={handleDrop}
       >
         <img
-          src={previewImage || "/svg/userProfile.svg"}
+          src={previewImage || DEFAULT_PROFILE}
           className={cn(
             "h-40 w-40 rounded-full border-2 border-solid border-white bg-gray-200 object-cover",
             !previewImage ? "bg-white" : "",

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 
 import { cn } from "@/lib/utils";
 import usePutProfile from "@/apis/auth/usePutProfile";
+import useToast from "@/hooks/common/useToast";
+import { AUTH_ERROR_MESSAGE, AUTH_SUCCESS_MESSAGE } from "@/constants/toastMessage";
 
 interface Props {
   profileImage: string | undefined;
@@ -14,6 +16,7 @@ const ImageUploadForm = ({ profileImage }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState(profileImage);
   const { uploadProfileImage } = usePutProfile();
+  const { showPromiseToast } = useToast();
 
   const handleClickUpload = () => {
     if (!inputRef.current) return;
@@ -23,13 +26,20 @@ const ImageUploadForm = ({ profileImage }: Props) => {
   const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const image = event.target.files?.[0];
     if (image) {
-      const imagePreviewUrl = URL.createObjectURL(image);
-      setPreviewImage(imagePreviewUrl);
-
       const formData = new FormData();
       formData.append("isCover", JSON.stringify(false));
       formData.append("profileImage", image);
-      uploadProfileImage(formData);
+      showPromiseToast({
+        promise: uploadProfileImage(formData),
+        messages: {
+          success: () => {
+            const imagePreviewUrl = URL.createObjectURL(image);
+            setPreviewImage(imagePreviewUrl);
+            return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
+          },
+          error: AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD,
+        },
+      });
     }
   };
 

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import { cn } from "@/lib/utils";
+
 const ImageUploadForm = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState("");
@@ -18,6 +20,10 @@ const ImageUploadForm = () => {
       const imagePreviewUrl = URL.createObjectURL(image);
       setPreviewImage(imagePreviewUrl);
     }
+  };
+
+  const handleRemoveImage = () => {
+    setPreviewImage("");
   };
 
   useEffect(() => {
@@ -46,7 +52,7 @@ const ImageUploadForm = () => {
         <Image className="mr-2" />
         사진 업로드
       </Button>
-      <Button variant="outline">
+      <Button variant="outline" onClick={handleRemoveImage}>
         <ImageOff className="mr-2" />
         사진 제거
       </Button>

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -15,6 +15,7 @@ interface Props {
 const ImageUploadForm = ({ profileImage }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState(profileImage);
+  const [isDragActive, setIsDragActive] = useState(false);
   const { uploadProfileImage } = usePutProfile();
   const { showPromiseToast } = useToast();
 
@@ -44,6 +45,26 @@ const ImageUploadForm = ({ profileImage }: Props) => {
     setPreviewImage("");
   };
 
+  const handleDragEnter = () => {
+    setIsDragActive(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDragActive(false);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragActive(true);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragActive(false);
+    const image = event.dataTransfer.files?.[0];
+    if (image) uploadImage(image);
+  };
+
   useEffect(() => {
     return () => {
       if (previewImage) URL.revokeObjectURL(previewImage);
@@ -59,14 +80,23 @@ const ImageUploadForm = ({ profileImage }: Props) => {
         accept="image/*"
         className="hidden"
       />
-      <img
-        src={previewImage || "/svg/userProfile.svg"}
-        className={cn(
-          "h-40 w-40 rounded-full bg-gray-200 object-cover",
-          !previewImage ? "bg-white" : "",
-        )}
-      />
-      <span className="my-1 text-xs text-gray-400">드래그하여 사진을 첨부해보세요!</span>
+      <div
+        className="flex h-40 w-full justify-center"
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        <img
+          src={previewImage || "/svg/userProfile.svg"}
+          className={cn(
+            "h-40 w-40 rounded-full border-2 border-solid border-white bg-gray-200 object-cover",
+            !previewImage ? "bg-white" : "",
+            isDragActive ? "border-2 border-dashed border-blue-500" : "",
+          )}
+        />
+      </div>
+      <span className="mb-1 mt-2 text-xs text-gray-400">드래그하여 사진을 첨부해보세요!</span>
       <Button className="my-2" onClick={handleClickUpload}>
         <Image className="mr-2" />
         사진 업로드

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,5 +1,5 @@
 import { Image, ImageOff } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import * as Sentry from "@sentry/react";
 
 import { Button } from "@/components/ui/button";
@@ -61,9 +61,8 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
     showPromiseToast({
       promise: uploadProfileImage(image),
       messages: {
-        success: () => {
-          const imagePreviewUrl = URL.createObjectURL(image);
-          setPreviewImage(imagePreviewUrl);
+        success: ({ image }) => {
+          setPreviewImage(image);
           Sentry.captureMessage("ui 사용 - 사용자 프로필 이미지 변경", "info");
           return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
         },
@@ -71,12 +70,6 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
       },
     });
   };
-
-  useEffect(() => {
-    return () => {
-      if (previewImage) URL.revokeObjectURL(previewImage);
-    };
-  }, [previewImage]);
 
   return (
     <div className="flex flex-col items-center">

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -5,12 +5,22 @@ import { Button } from "@/components/ui/button";
 
 const ImageUploadForm = () => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const handleClickUpload = () => {
+    if (!inputRef.current) return;
+    inputRef.current.click();
+  };
+
 
   return (
     <div className="flex flex-col items-center">
-      <input ref={inputRef} type="image" className="hidden" />
       <img className="h-40 w-40 rounded-sm bg-gray-200" />
-      <Button className="my-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+      />
+      <Button className="my-2" onClick={handleClickUpload}>
         <Image className="mr-2" />
         사진 업로드
       </Button>

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,4 +1,4 @@
-import { Image, ImageOff } from "lucide-react";
+import { Image } from "lucide-react";
 import { useRef, useState } from "react";
 import * as Sentry from "@sentry/react";
 
@@ -30,11 +30,6 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
   const handleChangeImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const image = event.target.files?.[0];
     if (image) uploadImage(image);
-  };
-
-  const handleRemoveImage = () => {
-    setPreviewImage("");
-    setIsClicked(true);
   };
 
   const handleDragEnter = () => {
@@ -97,13 +92,9 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
         />
       </div>
       <span className="mb-1 mt-2 text-xs text-gray-400">드래그하여 사진을 첨부해보세요!</span>
-      <Button className="my-2" onClick={handleClickUpload}>
+      <Button className="mt-2" onClick={handleClickUpload}>
         <Image className="mr-2" />
         사진 업로드
-      </Button>
-      <Button variant="outline" onClick={handleRemoveImage}>
-        <ImageOff className="mr-2" />
-        사진 제거
       </Button>
     </div>
   );

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -10,9 +10,10 @@ import { AUTH_ERROR_MESSAGE, AUTH_SUCCESS_MESSAGE } from "@/constants/toastMessa
 
 interface Props {
   profileImage: string | undefined;
+  setIsClicked: (isClicked: boolean) => void;
 }
 
-const ImageUploadForm = ({ profileImage }: Props) => {
+const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState(profileImage);
   const [isDragActive, setIsDragActive] = useState(false);
@@ -22,6 +23,7 @@ const ImageUploadForm = ({ profileImage }: Props) => {
   const handleClickUpload = () => {
     if (!inputRef.current) return;
     inputRef.current.click();
+    setIsClicked(true);
   };
 
   const handleChangeImage = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,6 +33,7 @@ const ImageUploadForm = ({ profileImage }: Props) => {
 
   const handleRemoveImage = () => {
     setPreviewImage("");
+    setIsClicked(true);
   };
 
   const handleDragEnter = () => {

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,5 +1,6 @@
 import { Image, ImageOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import * as Sentry from "@sentry/react";
 
 import { Button } from "@/components/ui/button";
 
@@ -63,6 +64,7 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
         success: () => {
           const imagePreviewUrl = URL.createObjectURL(image);
           setPreviewImage(imagePreviewUrl);
+          Sentry.captureMessage("ui 사용 - 사용자 프로필 이미지 변경", "info");
           return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
         },
         error: AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD,

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { cn } from "@/lib/utils";
+import usePutProfile from "@/apis/auth/usePutProfile";
 
 interface Props {
   profileImage: string | undefined;
@@ -12,6 +13,7 @@ interface Props {
 const ImageUploadForm = ({ profileImage }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previewImage, setPreviewImage] = useState(profileImage);
+  const { uploadProfileImage } = usePutProfile();
 
   const handleClickUpload = () => {
     if (!inputRef.current) return;
@@ -23,6 +25,11 @@ const ImageUploadForm = ({ profileImage }: Props) => {
     if (image) {
       const imagePreviewUrl = URL.createObjectURL(image);
       setPreviewImage(imagePreviewUrl);
+
+      const formData = new FormData();
+      formData.append("isCover", JSON.stringify(false));
+      formData.append("profileImage", image);
+      uploadProfileImage(formData);
     }
   };
 
@@ -52,6 +59,7 @@ const ImageUploadForm = ({ profileImage }: Props) => {
           !previewImage ? "bg-white" : "",
         )}
       />
+      <span className="my-1 text-xs text-gray-400">드래그하여 사진을 첨부해보세요!</span>
       <Button className="my-2" onClick={handleClickUpload}>
         <Image className="mr-2" />
         사진 업로드

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -5,9 +5,13 @@ import { Button } from "@/components/ui/button";
 
 import { cn } from "@/lib/utils";
 
-const ImageUploadForm = () => {
+interface Props {
+  profileImage: string | undefined;
+}
+
+const ImageUploadForm = ({ profileImage }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [previewImage, setPreviewImage] = useState("");
+  const [previewImage, setPreviewImage] = useState(profileImage);
 
   const handleClickUpload = () => {
     if (!inputRef.current) return;

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,24 +1,46 @@
 import { Image, ImageOff } from "lucide-react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
 const ImageUploadForm = () => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [previewImage, setPreviewImage] = useState("");
+
   const handleClickUpload = () => {
     if (!inputRef.current) return;
     inputRef.current.click();
   };
 
+  const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const image = event.target.files?.[0];
+    if (image) {
+      const imagePreviewUrl = URL.createObjectURL(image);
+      setPreviewImage(imagePreviewUrl);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (previewImage) URL.revokeObjectURL(previewImage);
+    };
+  }, [previewImage]);
 
   return (
     <div className="flex flex-col items-center">
-      <img className="h-40 w-40 rounded-sm bg-gray-200" />
       <input
+        onChange={handleUploadImage}
         ref={inputRef}
         type="file"
         accept="image/*"
         className="hidden"
+      />
+      <img
+        src={previewImage || "/svg/userProfile.svg"}
+        className={cn(
+          "h-40 w-40 rounded-full bg-gray-200 object-cover",
+          !previewImage ? "bg-white" : "",
+        )}
       />
       <Button className="my-2" onClick={handleClickUpload}>
         <Image className="mr-2" />

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -26,9 +26,6 @@ const ImageUploadForm = ({ profileImage }: Props) => {
   const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const image = event.target.files?.[0];
     if (image) {
-      const formData = new FormData();
-      formData.append("isCover", JSON.stringify(false));
-      formData.append("profileImage", image);
       showPromiseToast({
         promise: uploadProfileImage(formData),
         messages: {

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -24,21 +24,9 @@ const ImageUploadForm = ({ profileImage }: Props) => {
     inputRef.current.click();
   };
 
-  const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const image = event.target.files?.[0];
-    if (image) {
-      showPromiseToast({
-        promise: uploadProfileImage(formData),
-        messages: {
-          success: () => {
-            const imagePreviewUrl = URL.createObjectURL(image);
-            setPreviewImage(imagePreviewUrl);
-            return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
-          },
-          error: AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD,
-        },
-      });
-    }
+    if (image) uploadImage(image);
   };
 
   const handleRemoveImage = () => {
@@ -65,6 +53,20 @@ const ImageUploadForm = ({ profileImage }: Props) => {
     if (image) uploadImage(image);
   };
 
+  const uploadImage = (image: File) => {
+    showPromiseToast({
+      promise: uploadProfileImage(image),
+      messages: {
+        success: () => {
+          const imagePreviewUrl = URL.createObjectURL(image);
+          setPreviewImage(imagePreviewUrl);
+          return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
+        },
+        error: AUTH_ERROR_MESSAGE.PROFILE_IMAGE_UPLOAD,
+      },
+    });
+  };
+
   useEffect(() => {
     return () => {
       if (previewImage) URL.revokeObjectURL(previewImage);
@@ -74,7 +76,7 @@ const ImageUploadForm = ({ profileImage }: Props) => {
   return (
     <div className="flex flex-col items-center">
       <input
-        onChange={handleUploadImage}
+        onChange={handleChangeImage}
         ref={inputRef}
         type="file"
         accept="image/*"

--- a/src/components/Layout/Modals/Profile/index.tsx
+++ b/src/components/Layout/Modals/Profile/index.tsx
@@ -7,6 +7,7 @@ import SimpleBaseForm from "../Base/form";
 import SimpleBaseModal from "../Base/modal";
 
 import { makeFormFields, PROFILE_FIELDS, PROFILE_FIELDS_SCHEMA } from "./config";
+import ImageUploadForm from "./ImageUploadForm";
 
 import useGetUserInfo from "@/apis/auth/useGetUserInfo";
 import usePutProfile from "@/apis/auth/usePutProfile";
@@ -26,7 +27,7 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
   if (open && !isPending && user) makeFormFields(user);
 
   useEffect(() => {
-    if (open) toast.info("닉네임과 비밀번호 설정이 각각 가능합니다.");
+    if (open) toast.info("프로필 이미지와 닉네임, 비밀번호 설정이 각각 가능합니다.");
   }, [open]);
 
   const handleSubmit = ({ name, nickname, password }: z.infer<typeof PROFILE_FIELDS_SCHEMA>) => {
@@ -87,7 +88,9 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
         onSubmit={handleSubmit}
         submitText="저장"
         cancelText="취소"
-      />
+      >
+        <ImageUploadForm />
+      </SimpleBaseForm>
     </SimpleBaseModal>
   );
 };

--- a/src/components/Layout/Modals/Profile/index.tsx
+++ b/src/components/Layout/Modals/Profile/index.tsx
@@ -89,7 +89,7 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
         submitText="저장"
         cancelText="취소"
       >
-        <ImageUploadForm />
+        <ImageUploadForm profileImage={user?.image} />
       </SimpleBaseForm>
     </SimpleBaseModal>
   );

--- a/src/components/Layout/Modals/Profile/index.tsx
+++ b/src/components/Layout/Modals/Profile/index.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { toast } from "sonner";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/react";
 
 import SimpleBaseForm from "../Base/form";
@@ -23,6 +23,7 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
   const { user, isPending } = useGetUserInfo();
   const { updateUserName, updatePassword, updateAllProfile } = usePutProfile();
   const { showPromiseToast } = useToast();
+  const [isClickedUploadImage, setIsClickedUploadImage] = useState(false);
 
   if (open && !isPending && user) makeFormFields(user);
 
@@ -71,7 +72,10 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
           error: AUTH_ERROR_MESSAGE.UPDATE_ALL_PROFILE,
         },
       });
-    } else toast.warning(AUTH_ERROR_MESSAGE.NO_CHANGE);
+    } else {
+      if (!isClickedUploadImage) toast.warning(AUTH_ERROR_MESSAGE.NO_CHANGE);
+      else setIsClickedUploadImage(false);
+    }
   };
 
   return (
@@ -89,7 +93,7 @@ const ProfileModal = ({ open, toggleOpen }: Props) => {
         submitText="저장"
         cancelText="취소"
       >
-        <ImageUploadForm profileImage={user?.image} />
+        <ImageUploadForm profileImage={user?.image} setIsClicked={setIsClickedUploadImage} />
       </SimpleBaseForm>
     </SimpleBaseModal>
   );

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -7,17 +7,20 @@ import { parseTitleOrComment } from "@/utils/parsingJson";
 
 import { Comment } from "@/types/thread";
 
+import { ANONYMOUS_NICKNAME } from "@/constants/commonConstants";
+
 interface Props {
   commentInfo: Comment;
   onClose: (commentId: string) => void;
   isAuthor: boolean;
+  profileImage: string | undefined;
 }
 
 /**
  * 일관성 유지를 위해 ThreadListItem의 기능을 단순히 제거한 버전으로 스타일의 변경은 없는 코드이다.
  * 컴포넌트 통합 혹은 중복 코드 제거 등의 책임은 ThreadListItem 작성자에게 있다.
  */
-const CommentListItem = ({ commentInfo, onClose, isAuthor }: Props) => {
+const CommentListItem = ({ commentInfo, onClose, isAuthor, profileImage }: Props) => {
   const { createdAt, comment, _id } = commentInfo;
   const { content, nickname, mentionedList } = parseTitleOrComment(comment);
 
@@ -34,7 +37,14 @@ const CommentListItem = ({ commentInfo, onClose, isAuthor }: Props) => {
       )}
       <div className="flex items-center">
         <Avatar className="mr-3">
-          <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
+          <AvatarImage
+            src={
+              nickname !== ANONYMOUS_NICKNAME && profileImage
+                ? profileImage
+                : "/svg/userProfile.svg"
+            }
+            alt="프로필"
+          />
           <AvatarFallback className="text-content-1 bg-layer-5">
             {nickname?.charAt(0)}
           </AvatarFallback>

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -7,7 +7,7 @@ import { parseTitleOrComment } from "@/utils/parsingJson";
 
 import { Comment } from "@/types/thread";
 
-import { ANONYMOUS_NICKNAME } from "@/constants/commonConstants";
+import { ANONYMOUS_NICKNAME, DEFAULT_PROFILE } from "@/constants/commonConstants";
 
 interface Props {
   commentInfo: Comment;
@@ -38,11 +38,7 @@ const CommentListItem = ({ commentInfo, onClose, isAuthor, profileImage }: Props
       <div className="flex items-center">
         <Avatar className="mr-3">
           <AvatarImage
-            src={
-              nickname !== ANONYMOUS_NICKNAME && profileImage
-                ? profileImage
-                : "/svg/userProfile.svg"
-            }
+            src={nickname !== ANONYMOUS_NICKNAME && profileImage ? profileImage : DEFAULT_PROFILE}
             alt="프로필"
           />
           <AvatarFallback className="text-content-1 bg-layer-5">

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -70,6 +70,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
               commentInfo={comment}
               onClose={handleDeleteComment}
               isAuthor={comment.author._id === user?._id}
+              profileImage={comment.author.image}
             />
           ))}
         </ol>

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -20,6 +20,7 @@ import useToast from "@/hooks/common/useToast";
 import LoginModal from "@/components/Layout/Modals/Login";
 import RegisterModal from "@/components/Layout/Modals/Register";
 import { cn } from "@/lib/utils";
+import { ANONYMOUS_NICKNAME, DEFAULT_PROFILE } from "@/constants/commonConstants";
 
 interface Props {
   thread: Thread;
@@ -116,7 +117,7 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
               src={
                 author.nickname !== ANONYMOUS_NICKNAME && author.image
                   ? author.image
-                  : "/svg/userProfile.svg"
+                  : DEFAULT_PROFILE
               }
               alt="프로필"
             />

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -112,7 +112,14 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
       {editingThreadId !== id && (
         <div className="flex" onClick={onClick}>
           <Avatar className="mr-3">
-            <AvatarImage src="/svg/userProfile.svg" alt="프로필" />
+            <AvatarImage
+              src={
+                author.nickname !== ANONYMOUS_NICKNAME && author.image
+                  ? author.image
+                  : "/svg/userProfile.svg"
+              }
+              alt="프로필"
+            />
             <AvatarFallback>{author.nickname.charAt(0)}</AvatarFallback>
           </Avatar>
           <div className="min-w-0 flex-grow">

--- a/src/constants/commonConstants.ts
+++ b/src/constants/commonConstants.ts
@@ -1,1 +1,3 @@
 export const ANONYMOUS_NICKNAME = "익명의 프롱이";
+
+export const DEFAULT_PROFILE = "/svg/userProfile.svg";

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -11,6 +11,7 @@ export const AUTH_ERROR_MESSAGE = {
   UPDATE_ALL_PROFILE: "닉네임과 비밀번호 설정에 실패하였습니다.",
   NO_CHANGE: "변경된 사항이 없습니다.",
   LOGOUT: "로그아웃에 실패했습니다 :(",
+  PROFILE_IMAGE_UPLOAD: "프로필 이미지 업로드에 실패했습니다.",
 };
 
 export const AUTH_SUCCESS_MESSAGE = {
@@ -18,6 +19,7 @@ export const AUTH_SUCCESS_MESSAGE = {
   UPDATE_PASSWORD: "비밀번호가 수정되었습니다.",
   UPDATE_ALL_PROFILE: "닉네임과 비밀번호가 수정되었습니다.",
   LOGOUT: "로그아웃 되었습니다 :D",
+  PROFILE_IMAGE_UPLOAD: "프로필 이미지가 업로드 되었습니다!",
   LOGIN(nickname: string) {
     return `어서오세요, ${nickname}님!`;
   },

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -1,6 +1,7 @@
 export const AUTH_ERROR_RESPONSE = {
   ALREADY_USED_EMAIL: "The email address is already being used.",
   LOGIN_FAILED: "Your email and password combination does not match an account.",
+  IMAGE_UNMATCHED: "Please upload an image.",
 };
 
 export const AUTH_ERROR_MESSAGE = {
@@ -11,6 +12,7 @@ export const AUTH_ERROR_MESSAGE = {
   UPDATE_ALL_PROFILE: "닉네임과 비밀번호 설정에 실패하였습니다.",
   NO_CHANGE: "낙네임이나 비밀번호를 변경하지 않았습니다.",
   LOGOUT: "로그아웃에 실패했습니다 :(",
+  IMAGE_UNMATCHED: "이미지를 첨부해주세요!",
   PROFILE_IMAGE_UPLOAD: "프로필 이미지 업로드에 실패했습니다.",
 };
 

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -9,7 +9,7 @@ export const AUTH_ERROR_MESSAGE = {
   LOGIN_FAILED: "이메일과 비밀번호가 일치하지 않습니다.",
   SERVER_ERROR: "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요.",
   UPDATE_ALL_PROFILE: "닉네임과 비밀번호 설정에 실패하였습니다.",
-  NO_CHANGE: "변경된 사항이 없습니다.",
+  NO_CHANGE: "낙네임이나 비밀번호를 변경하지 않았습니다.",
   LOGOUT: "로그아웃에 실패했습니다 :(",
   PROFILE_IMAGE_UPLOAD: "프로필 이미지 업로드에 실패했습니다.",
 };


### PR DESCRIPTION
## 📝 작업 내용

(500 에러난다고 했던 부분은 .. FormData에 키 값이 맞지 않아 난 에러였답니다 .. 총총)

- 프로필 이미지 업로드는 사진 첨부 시 바로 api 통신
    - 성공 시 이미지 미리보기 + 토스트 메시지 띄워짐, 실패 시에는 토스트 메시지만 출력

- 드래그 앤 드랍으로 이미지 첨부 가능

- 프로필이 있는 유저 + 기명으로 작성한 경우 스레드, 댓글에 프로필 이미지 나오도록 처리

### 스크린샷

![화면 기록 2024-01-15 오전 10 19 05](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/7efd2cea-1b27-4eca-aaad-ec912ec04817)


## 💬 리뷰 요구사항

프로필 삭제하는 기능이 현재 제공되는 api에서 구현되고 있는 것 같지 않아 이미지 제거 버튼 삭제했습니다.
삭제하는 경우에는 

```ts
  const formData = new FormData();
  formData.append("image", new File([], ""));
```

이런 식으로 formData에 넣어봐도 이미지를 넣으라는 400 에러가 떠서 삭제 기능은 구현하지 않았는데 혹은 제가 잘못된 방법으로 구현한 것인지 궁금합니다.

close #98 
