### PR TITLE
[#188] Modify: 로그인/자동 로그인 토스트 메시지 분리

### DIFF
--- a/src/apis/auth/usePostLogout.ts
+++ b/src/apis/auth/usePostLogout.ts
@@ -14,6 +14,7 @@ const usePostLogout = () => {
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: auth.userInfo(token).queryKey });
       removeLocalStorage("token");
+      removeLocalStorage("isLogin");
       if (location.pathname.includes("my")) location.pathname = "/";
     },
   });

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -7,7 +7,7 @@ import { useOverlay } from "@toss/use-overlay";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
-import { getLocalStorage } from "@/utils/localStorage";
+import { getLocalStorage, setLocalStorage } from "@/utils/localStorage";
 
 import LoginModal from "../Modals/Login";
 import ProfileModal from "../Modals/Profile";
@@ -53,10 +53,14 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
   const { open } = useOverlay();
 
   const isLoggedIn = !!getLocalStorage("token", "");
+  const alreadyLoggedIn = getLocalStorage("isLogin", false);
 
   useEffect(() => {
-    if (isLoggedIn) toast.success("로그인 되었습니다 :D");
-  }, [isLoggedIn]);
+    if (isLoggedIn) {
+      if (!alreadyLoggedIn) setLocalStorage("isLogin", true);
+      else toast.success("자동 로그인 되었습니다 :D");
+    }
+  }, [isLoggedIn, alreadyLoggedIn]);
 
   const handleLoginModalOpen = () => {
     open(({ isOpen, close }) => {

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -56,10 +56,10 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
   const alreadyLoggedIn = getLocalStorage("isLogin", false);
 
   useEffect(() => {
-    if (isLoggedIn) {
-      if (!alreadyLoggedIn) setLocalStorage("isLogin", true);
-      else toast.success("자동 로그인 되었습니다 :D");
-    }
+    if (!isLoggedIn) return;
+
+    if (!alreadyLoggedIn) setLocalStorage("isLogin", true);
+    else toast.success("자동 로그인 되었습니다 :D");
   }, [isLoggedIn, alreadyLoggedIn]);
 
   const handleLoginModalOpen = () => {


### PR DESCRIPTION
## 📝 작업 내용

로그인 모달을 통해 로그인 했을 때와 새로고침, 재방문 시 자동 로그인 했을 때의 토스트 메시지를 분리 했습니다.

- 로컬 스토리지를 통해 토큰이 있는데 로컬 스토리지에 저장된 `isLogin` 값이 없거나 false인 경우
    - 로그인 모달로 로그인 한 것으로 스토리지에 true로 저장 + 로그인 성공 메시지
- 로컬 스토리지를 통해 토큰이 있는데 로컬 스토리지에 저장된 `isLogin` 값이 true인 경우
    - 자동 로그인으로 인지 > 자동 로그인 메시지
- 로그아웃 시 `isLogin` 값을 삭제했습니다.

### 📷 스크린샷

![화면 기록 2024-01-15 오후 8 59 22](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/73841260/a2a3726c-4e5c-4416-b219-af4081ed40a3)

## 💬 리뷰 요구사항

- 로직이 맞는지 궁금합니다.

close #188 
