### PR TITLE
[#196] Modify: 날짜 포맷팅 함수 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
-    "date-fns": "^3.0.6",
+    "date-fns": "^3.2.0",
     "embla-carousel-react": "^8.0.0-rc17",
     "lucide-react": "^0.302.0",
     "nanoid": "^5.0.4",

--- a/src/components/MyNotifications/CommentNotification.tsx
+++ b/src/components/MyNotifications/CommentNotification.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@/utils/formatDate.ts";
+import { formatDateFns } from "@/utils/formatDateFns";
 
 import { MyNotificationContent } from "@/components/MyNotifications/MyNotificationItem.tsx";
 
@@ -8,7 +8,7 @@ interface Props {
   createdAt: string;
 }
 const CommentNotification = ({ postId, comment, createdAt }: Props) => {
-  const createdDate = formatDate(createdAt);
+  const createdDate = formatDateFns(createdAt);
   let content = "";
   try {
     content = JSON.parse(comment).content;

--- a/src/components/MyNotifications/LikeNotification.tsx
+++ b/src/components/MyNotifications/LikeNotification.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@/utils/formatDate.ts";
+import { formatDateFns } from "@/utils/formatDateFns";
 
 import { LikeByNotification } from "@/types/thread";
 
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const LikeNotification = ({ createdAt, like }: Props) => {
-  const createdDate = formatDate(createdAt);
+  const createdDate = formatDateFns(createdAt);
 
   const { content } = JSON.parse(like.post.title);
 

--- a/src/components/MyNotifications/MentionNotification.tsx
+++ b/src/components/MyNotifications/MentionNotification.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@/utils/formatDate.ts";
+import { formatDateFns } from "@/utils/formatDateFns";
 
 import { MyNotificationContent } from "@/components/MyNotifications/MyNotificationItem.tsx";
 
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const MentionNotification = ({ message, createdAt }: Props) => {
-  const createdDate = formatDate(createdAt);
+  const createdDate = formatDateFns(createdAt);
   const { channelName, postId, content } = JSON.parse(message);
 
   return (

--- a/src/components/MyThreads/MyThreadItem.tsx
+++ b/src/components/MyThreads/MyThreadItem.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from "@/utils/formatDate";
+import { formatDateFns } from "@/utils/formatDateFns";
 
 import MyPost from "./MyPost";
 import MyComment from "./MyComment";
@@ -21,7 +21,7 @@ const channelMap = {
 };
 
 const MyThreadItem = ({ title, type, channel, createdAt, comment, onClick }: Props) => {
-  const createdDate = formatDate(createdAt);
+  const createdDate = formatDateFns(createdAt);
   const headerText = channel ? `#${channelMap[channel]}게시판` : "#작성한 댓글";
 
   return (

--- a/src/utils/formatDateFns.ts
+++ b/src/utils/formatDateFns.ts
@@ -1,0 +1,22 @@
+import { format, formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
+
+const formatDate = (date: Date) => {
+  const now = Date.now();
+  const diff = (now - date.getTime()) / 1000; // 현재 시간과의 차이(초)
+  if (diff < 60 * 1) {
+    // 1분 미만일땐 방금 전 표기
+    return "방금 전";
+  }
+  if (diff < 60 * 60 * 24 * 3) {
+    // 3일 미만일땐 시간차이 출력(몇시간 전, 몇일 전)
+    return formatDistanceToNow(date, { addSuffix: true, locale: ko });
+  }
+  return format(date, "PPP ", { locale: ko }); // 날짜 포맷
+};
+
+export const formatDateFns = (dateString: string) => {
+  const date = new Date(dateString);
+
+  return formatDate(date);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,10 +2518,10 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-date-fns@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.0.6.tgz#fe3aeb7592d359f075ffc41cb16139828810ca83"
-  integrity sha512-W+G99rycpKMMF2/YD064b2lE7jJGUe+EjOES7Q8BIGY8sbNdbgcs9XFTZwvzc9Jx1f3k7LB7gZaZa7f8Agzljg==
+date-fns@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.2.0.tgz#c97cf685b62c829aa4ecba554e4a51768cf0bffc"
+  integrity sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==
 
 debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
## 📝 작업 내용

date-fns 라이브러리를 설치하고 함수를 추가하였습니다.
기존의 데나무숲은 DateFormat함수를 활용하여 하루가 지난 글은 모두 "n년n월n일" 의 형식으로 표현하였습니다.
새로 추가된 DateFormatFns 함수를 활용하면 3일 전까지 표시가 가능합니다.

### 📷 스크린샷 (선택)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/91151775/dff6a9d1-4246-44ac-9baa-82f71c721b43)

기존) 해당 일의 글 = n시 n분
         이전 일의 글 = n년 n시 n분

변경) 24시간 이내의 글 = 방금 전, n시간 전
         1일~3일 이내의 글 = n일 전
         3일 보다 오래된 글 =n년 n시 n분

## 💬 리뷰 요구사항(선택)

새 라이브러리가 추가되었으니 install 부탁드립니다!

close #196 
