### PR TITLE
[#202] Refactor: Sentry -> GA4 로그 수집 위치 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint",
-      "prettier"
+      "prettier --check"
     ],
-    "*.{css,json,html}": "prettier"
+    "*.{css,json,html}": "prettier --check"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
+    "@types/gtag.js": "^0.0.18",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.16.0",

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { AxiosError } from "axios";
-import * as Sentry from "@sentry/react";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Button } from "@/components/ui/button";
@@ -42,7 +41,7 @@ const LoginModal = ({ open, close }: Props) => {
       messages: {
         success: ({ user: { fullName } }) => {
           close();
-          Sentry.captureMessage("retention - 로그인", "info");
+          gtag("event", "retention_로그인");
           const { nickname } = JSON.parse(fullName);
           return AUTH_SUCCESS_MESSAGE.LOGIN(nickname);
         },

--- a/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
+++ b/src/components/Layout/Modals/Profile/ImageUploadForm.tsx
@@ -1,6 +1,5 @@
 import { Image } from "lucide-react";
 import { useRef, useState } from "react";
-import * as Sentry from "@sentry/react";
 import { AxiosError } from "axios";
 
 import { Button } from "@/components/ui/button";
@@ -64,7 +63,7 @@ const ImageUploadForm = ({ profileImage, setIsClicked }: Props) => {
       messages: {
         success: ({ image }) => {
           setPreviewImage(image);
-          Sentry.captureMessage("ui 사용 - 사용자 프로필 이미지 변경", "info");
+          gtag("event", "ui사용_사용자_프로필_이미지_변경");
           return AUTH_SUCCESS_MESSAGE.PROFILE_IMAGE_UPLOAD;
         },
         error: (error: AxiosError) => {

--- a/src/components/Layout/Modals/Profile/index.tsx
+++ b/src/components/Layout/Modals/Profile/index.tsx
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { toast } from "sonner";
 import { useEffect, useState } from "react";
-import * as Sentry from "@sentry/react";
 
 import SimpleBaseForm from "../Base/form";
 import SimpleBaseModal from "../Base/modal";
@@ -42,7 +41,7 @@ const ProfileModal = ({ open, close }: Props) => {
         messages: {
           success: () => {
             close();
-            Sentry.captureMessage("ui 사용 - 사용자 닉네임 변경", "info");
+            gtag("event", "ui사용_사용자_닉네임_변경");
             return AUTH_SUCCESS_MESSAGE.UPDATE_PROFILE;
           },
           error: AUTH_ERROR_MESSAGE.SERVER_ERROR,
@@ -54,7 +53,7 @@ const ProfileModal = ({ open, close }: Props) => {
         messages: {
           success: () => {
             close();
-            Sentry.captureMessage("ui 사용 - 사용자 비밀번호 변경", "info");
+            gtag("event", "ui사용_사용자_비밀번호_변경");
             return AUTH_SUCCESS_MESSAGE.UPDATE_PASSWORD;
           },
           error: AUTH_ERROR_MESSAGE.SERVER_ERROR,
@@ -66,7 +65,7 @@ const ProfileModal = ({ open, close }: Props) => {
         messages: {
           success: () => {
             close();
-            Sentry.captureMessage("ui 사용 - 사용자 프로필 변경", "info");
+            gtag("event", "ui사용_사용자 프로필 변경");
             return AUTH_SUCCESS_MESSAGE.UPDATE_ALL_PROFILE;
           },
           error: AUTH_ERROR_MESSAGE.UPDATE_ALL_PROFILE,

--- a/src/components/Layout/Modals/Register/index.tsx
+++ b/src/components/Layout/Modals/Register/index.tsx
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { AxiosError } from "axios";
-import * as Sentry from "@sentry/react";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Button } from "@/components/ui/button";
@@ -44,7 +43,7 @@ const RegisterModal = ({ open, close }: Props) => {
   useEffect(() => {
     if (isRegisterSuccess) {
       handleLoginClick();
-      Sentry.captureMessage("conversion - 회원 가입 완료", "info");
+      gtag("event", "conversion_회원_가입_완료");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRegisterSuccess]);

--- a/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
+++ b/src/components/Layout/Sidebar/ThemeConfigDropdown.tsx
@@ -1,6 +1,5 @@
 import { MoonIcon, SunIcon } from "lucide-react";
 import { PropsWithChildren } from "react";
-import * as Sentry from "@sentry/react";
 
 import {
   DropdownMenu,
@@ -23,14 +22,14 @@ export const ThemeConfigDropdown = ({ children }: PropsWithChildren) => {
     log("info", "dark");
     localStorage.setItem("theme", "dark");
     document.documentElement.classList.add("dark");
-    Sentry.captureMessage("ui 사용 - 테마 변경 옵션 띄우기 (Dark)", "info");
+    gtag("event", "ui사용_테마_변경_Dark");
   };
 
   const handleLightModeClick = () => {
     log("info", "light");
     localStorage.setItem("theme", "light");
     document.documentElement.classList.remove("dark");
-    Sentry.captureMessage("ui 사용 - 테마 변경 옵션 띄우기 (Light)", "info");
+    gtag("event", "ui사용_테마_변경_Light");
   };
 
   return (

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router-dom";
 import { LogIn, MoonIcon, SunIcon, UserRoundCog, LogOut, HelpCircle } from "lucide-react";
 import { useEffect } from "react";
 import { toast } from "sonner";
-import * as Sentry from "@sentry/react";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -71,14 +70,14 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
 
   const handleProfileModalOpen = () => {
     open(({ isOpen, close }) => {
-      Sentry.captureMessage("ui 사용 - 사용자 정보 변경 모달 띄우기", "info");
+      gtag("event", "ui사용_사용자_정보_변경_모달_띄우기");
       return <ProfileModal open={isOpen} close={close} />;
     });
   };
 
   const handleInfoModalOpen = () => {
     open(({ isOpen, close }) => {
-      Sentry.captureMessage("ui 사용 - 이용 방법 모달 띄우기", "info");
+      gtag("event", "ui사용_이용_방법_모달_띄우기");
       return <InformationModal open={isOpen} close={close} />;
     });
   };
@@ -91,11 +90,11 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
         error: AUTH_ERROR_MESSAGE.LOGOUT,
       },
     });
-    Sentry.captureMessage("retention - 로그아웃", "info");
+    gtag("event", "retention_로그아웃");
   };
 
   const handleThemeChange = () => {
-    Sentry.captureMessage("ui 사용 - 테마 변경 옵션 띄우기", "info");
+    gtag("event", "ui사용_테마_변경_옵션_띄우기");
   };
 
   /*
@@ -113,7 +112,7 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
           {isLoggedIn ? (
             <Avatar className="flex items-center">
               <AvatarImage src={profileImgUrl} alt={nickname} />
-              <AvatarFallback className="text-content-6 bg-layer-3 dark:bg-blue-300">
+              <AvatarFallback className="bg-layer-3 text-content-6 dark:bg-blue-300">
                 {shortenedNickname}
               </AvatarFallback>
             </Avatar>

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -1,7 +1,6 @@
 import { useForm } from "react-hook-form";
 import { SendHorizontal } from "lucide-react";
 import { FormEvent, KeyboardEvent, useState } from "react";
-import * as Sentry from "@sentry/react";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Textarea } from "@/components/ui/textarea.tsx";
@@ -68,7 +67,7 @@ const EditorTextArea = ({
         message: "로그인 한 유저만 글 쓰기가 가능합니다.",
         actionLabel: "로그인",
         onActionClick: () => {
-          Sentry.captureMessage("Conversion: 익명 사용자가 로그인 요청을 수락", "info");
+          gtag("event", "conversion_익명_사용자가_로그인_요청을_수락");
           open(({ isOpen, close }) => {
             return <LoginModal open={isOpen} close={close} />;
           });
@@ -80,7 +79,7 @@ const EditorTextArea = ({
     setMentionedList([]);
     setValue("content", "");
     onEditClose?.();
-    Sentry.captureMessage(`ui 사용 - 에디터 쓰기 ${getTypeOfEditor(editorProps)}`, "info");
+    gtag("event", `ui사용_에디터_쓰기_${getTypeOfEditor(editorProps)}`);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -96,10 +95,10 @@ const EditorTextArea = ({
   const handleClickCheckBox = (e: FormEvent<HTMLInputElement>) => {
     // TODO: [24/1/11] nickname은 props로 받아오는게 맞다고 생각합니다. 하지만 여러곳에서 수정이 필요해지니 현재 에디터에 user를 가지고 있어서 임시방편으로 수정하겠습니다.
     if (!e.currentTarget.checked && user?.nickname === ANONYMOUS_NICKNAME) {
-      Sentry.captureMessage("ui 사용 - 익명 여부 토글", "info");
+      gtag("event", "ui사용_익명_여부_토글");
       setValue("anonymous", true);
       open(({ isOpen, close }) => {
-        Sentry.captureMessage("ui 사용 - 사용자 정보 변경 모달 띄우기", "info");
+        gtag("event", "ui사용_사용자_정보_변경_모달_띄우기");
         return <ProfileModal open={isOpen} close={close} />;
       });
       return;
@@ -115,24 +114,24 @@ const EditorTextArea = ({
       <form className="relative">
         <Textarea
           placeholder={user ? `내용을 작성해주세요.` : "로그인이 필요합니다."}
-          className="text-content-5 resize-none overflow-hidden pr-200pxr text-base"
+          className="resize-none overflow-hidden pr-200pxr text-base text-content-5"
           {...register("content")}
           onKeyDown={handleKeydown}
         />
         <div className="absolute bottom-2 right-2 flex items-center gap-2">
-          <label className="border-layer-5 hover:bg-layer-2 flex cursor-pointer items-center gap-2 rounded-xl border p-3">
+          <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-layer-5 p-3 hover:bg-layer-2">
             <input type="checkbox" {...register("anonymous")} onClick={handleClickCheckBox} />
             <p className="text-content-4">익명</p>
           </label>
           {onEditClose ? (
-            <div className="text-content-4 flex items-center gap-2">
-              <button className="bg-layer-3 hover:bg-layer-4 rounded-sm p-3" onClick={onEditClose}>
+            <div className="flex items-center gap-2 text-content-4">
+              <button className="rounded-sm bg-layer-3 p-3 hover:bg-layer-4" onClick={onEditClose}>
                 취소
               </button>
               <button
                 onClick={handleSubmit(handleUpload)}
                 className={cn(
-                  "text-content-5 border-layer-2 rounded-sm border p-3",
+                  "rounded-sm border border-layer-2 p-3 text-content-5",
                   watch("content")
                     ? "border-blue-100 bg-blue-100 dark:text-blue-600"
                     : "cursor-not-allowed",
@@ -145,7 +144,7 @@ const EditorTextArea = ({
             <button
               onClick={handleSubmit(handleUpload)}
               className={cn(
-                "text-content-1 bg-layer-4 relative h-12 w-12 cursor-pointer rounded-xl",
+                "relative h-12 w-12 cursor-pointer rounded-xl bg-layer-4 text-content-1",
                 watch("content") && "bg-blue-200 text-blue-600",
               )}
             >
@@ -161,7 +160,7 @@ const EditorTextArea = ({
       </form>
       <span
         className={cn(
-          "text-content-1 text-right text-sm",
+          "text-right text-sm text-content-1",
           getValues("content") ? "visible" : "invisible",
         )}
       >

--- a/src/components/common/mention/MentionInput.tsx
+++ b/src/components/common/mention/MentionInput.tsx
@@ -7,7 +7,6 @@ import {
   Dispatch,
   SetStateAction,
 } from "react";
-import * as Sentry from "@sentry/react";
 
 import { Input } from "@/components/ui/input.tsx";
 
@@ -49,7 +48,7 @@ const MentionInput = ({ mentionedList, onChoose }: Props) => {
       onChoose((prev) => [...prev, people]);
     }
 
-    Sentry.captureMessage("ui 사용 - Mention", "info");
+    gtag("event", "ui사용_Mention");
     emptyUserInput();
   };
 
@@ -93,7 +92,7 @@ const MentionInput = ({ mentionedList, onChoose }: Props) => {
         onKeyDown={handleKeyDown}
         ref={inputRef}
         placeholder="멘션할 대상을 선택해주세요."
-        className="text-content-5 placeholder-content-1 text-base"
+        className="text-base text-content-5 placeholder-content-1"
       />
 
       <AutoCompleteMentionList

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, useState } from "react";
-import * as Sentry from "@sentry/react";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
@@ -84,7 +83,7 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
   const handleClickDeleteButton = (event: MouseEvent) => {
     event.stopPropagation();
     deleteThread(id);
-    Sentry.captureMessage("ui 사용 - 스레드 삭제", "info");
+    gtag("event", "ui사용_스레드_삭제");
   };
 
   const handleClickEditButton = (threadId: string) => (event: MouseEvent) => {
@@ -102,7 +101,7 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
       key={id}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="hover:bg-layer-3 relative cursor-pointer px-2.5 py-5"
+      className="relative cursor-pointer px-2.5 py-5 hover:bg-layer-3"
       tabIndex={0}
     >
       {editingThreadId !== id && (
@@ -120,7 +119,7 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
           </Avatar>
           <div className="min-w-0 flex-grow">
             <div className="flex justify-between">
-              <span tabIndex={0} className="text-content-5 text-lg font-semibold">
+              <span tabIndex={0} className="text-lg font-semibold text-content-5">
                 {author.nickname}
               </span>
               <span tabIndex={0} className="text-content-2">
@@ -129,11 +128,11 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
             </div>
             <div
               tabIndex={0}
-              className={cn("text-content-5 mb-10pxr whitespace-pre-wrap pr-50pxr", {
+              className={cn("mb-10pxr whitespace-pre-wrap pr-50pxr text-content-5", {
                 "line-clamp-3 truncate": !isThreadDetail,
               })}
             >
-              <span className="text-content-6 font-bold">
+              <span className="font-bold text-content-6">
                 {mentionedList && `${mentionedList} `}
               </span>
               <span className="text-content-5">{content}</span>

--- a/src/hooks/api/useToggleLike.ts
+++ b/src/hooks/api/useToggleLike.ts
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/react";
-
 import usePostThreadLike from "@/apis/thread/usePostThreadLike";
 import useDeleteThreadLike from "@/apis/thread/useDeleteThreadLike";
 
@@ -17,12 +15,12 @@ const useToggleLike = ({ channelId, threadId }: Parameters) => {
 
     if (!likeId) {
       likeThread(threadId);
-      Sentry.captureMessage("ui 사용 - 좋아요 등록", "info");
+      gtag("event", "ui사용_좋아요_등록");
     }
 
     if (likeId) {
       removeLike(likeId);
-      Sentry.captureMessage("ui 사용 - 좋아요 삭제", "info");
+      gtag("event", "ui사용_좋아요_삭제");
     }
   };
 

--- a/src/pages/Error/index.tsx
+++ b/src/pages/Error/index.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/react";
 import { Terminal } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -12,7 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 const ErrorPage = () => {
   const handleGoToHomeClick = () => {
     window.location.href = "/";
-    Sentry.captureMessage(`ui 사용 - 오류 발생 후 홈으로 이동`, "info");
+    gtag("event", `ui사용_오류_발생_후_홈으로_이동`);
   };
 
   return (

--- a/src/pages/MyNotifications/index.tsx
+++ b/src/pages/MyNotifications/index.tsx
@@ -1,6 +1,3 @@
-import { useEffect } from "react";
-import * as Sentry from "@sentry/react";
-
 import useSelectedThreadStore from "@/stores/thread";
 
 import MyNotificationTitle from "@/components/MyNotifications/MyNotificationTitle";
@@ -21,10 +18,6 @@ const MyNotificationsPage = () => {
     putMyMentionedSeen(userInfo.user._id);
     putMyNotificationSeen();
   }
-
-  useEffect(() => {
-    Sentry.captureMessage("visit - MyNotificationsPage", "info");
-  }, []);
 
   return (
     <div className="h-screen overflow-auto p-30pxr">

--- a/src/pages/MyThreads/index.tsx
+++ b/src/pages/MyThreads/index.tsx
@@ -1,6 +1,3 @@
-import { useEffect } from "react";
-import * as Sentry from "@sentry/react";
-
 import useSelectedThreadStore from "@/stores/thread";
 
 import MyThreadDescription from "@/components/MyThreads/MyThreadDescription";
@@ -13,9 +10,6 @@ const MyThreadsPage = () => {
   const handleCloseThreadDetail = () => {
     selectThreadId(undefined);
   };
-  useEffect(() => {
-    Sentry.captureMessage("visit - MyThreadsPage", "info");
-  }, []);
 
   return (
     <div className="relative h-screen overflow-auto p-30pxr">

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,11 +1,4 @@
-import { useEffect } from "react";
-import * as Sentry from "@sentry/react";
-
 const NotFoundPage = () => {
-  useEffect(() => {
-    Sentry.captureMessage("visit - NotFoundPage", "info");
-  }, []);
-
   return <div></div>;
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,39 +1,33 @@
 import { VitePluginRadar } from "vite-plugin-radar";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 
-// env를 사용하기 위해선 loadEnv(mode)가 필요해 해당 방식을 사용
-// https://stackoverflow.com/questions/66389043/how-can-i-use-vite-env-variables-in-vite-config-js
-export default ({ mode }) => {
-  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+export default defineConfig({
+  plugins: [
+    react(),
+    svgr({
+      include: "**/*.svg",
+    }),
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      telemetry: false,
+    }),
+    VitePluginRadar({
+      enableDev: false,
+      analytics: {
+        id: process.env.GA4_ID,
+      },
+    }),
+  ],
 
-  return defineConfig({
-    plugins: [
-      react(),
-      svgr({
-        include: "**/*.svg",
-      }),
-      sentryVitePlugin({
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT,
-        telemetry: false,
-      }),
-      VitePluginRadar({
-        enableDev: false,
-        analytics: {
-          id: process.env.GA4_ID,
-        },
-      }),
-    ],
+  resolve: {
+    alias: [{ find: "@", replacement: "/src" }],
+  },
 
-    resolve: {
-      alias: [{ find: "@", replacement: "/src" }],
-    },
-
-    build: {
-      sourcemap: true,
-    },
-  });
-};
+  build: {
+    sourcemap: true,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,6 +1838,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/gtag.js@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.18.tgz#d6bc7cb1acc64ff4f4e4be918d401c53fe9ccf20"
+  integrity sha512-GJxnIvuXuVhKaHfsOdzGipoOoXq72y3mdcncc9h6i6E7nlz89zBEj2wrLM7bqO5Xk9Lm2B94MwdQsSwRlaPSWw==
+
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"


### PR DESCRIPTION
resolves #202 


## 📝 작업 내용

- Sentry에서 `type:info`로 집계해도 Error 개수에 들어가던 `Sentry.captureMessage`에서 GA4의 Event로 전환 (GA4 대시보드에서 확인)
- GA4의 전환 추적 등의 기능에 사용

- 로컬에서 정상 동작 확인
![image](https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/28754907/9c50e627-ead5-4797-b95f-3622a3d6534c)

## 번외

- Vite config에서 `VITE_` 가 필요 없는 경우 `loadEnv`가 필요 없어서 지웠습니다 (.env 파일을 읽는 경우가 아니어서 필요 없음)
- PR 일부에서 className 정렬 변경 사항도 같이 포함되어 있습니다. (단순 prettier --write)
- prettier lint가 안 된 상태 혹은 잘못 정렬된 상태(이유는 모르겠지만)로 통과하는 것 같은데 `prettier`가 아닌 `prettier --check`로 명령어 변경할게요(prettier로 포매팅 가능한 내용 있으면 warning 표시됨) -> 인지하셨으면 해당 pr에서 husky 바꿀게요
  - <img src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/28754907/408b559d-521a-4fee-9571-64ff27128820" width=500>