### PR TITLE
[#201] Fix: 댓글 추가, 삭제시 리스트 query key invalidate

### DIFF
--- a/src/apis/comment/useDeleteComment.ts
+++ b/src/apis/comment/useDeleteComment.ts
@@ -3,7 +3,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteComment } from "@/apis/comment/queryFn.ts";
 import threads from "@/apis/thread/queryKey.ts";
 
-const useDeleteComment = (threadId: string | undefined) => {
+interface Parameters {
+  threadId: string | undefined;
+  channelId: string | undefined;
+}
+
+const useDeleteComment = ({ threadId, channelId }: Parameters) => {
   const queryClient = useQueryClient();
 
   const { mutate, ...props } = useMutation({
@@ -11,6 +16,10 @@ const useDeleteComment = (threadId: string | undefined) => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: threads.threadDetail(threadId).queryKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadsByChannel(channelId).queryKey,
       });
     },
   });

--- a/src/apis/comment/usePostComment.ts
+++ b/src/apis/comment/usePostComment.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import threads from "@/apis/thread/queryKey";
 import { createComment } from "@/apis/comment/queryFn.ts";
 
-export const usePostComment = () => {
+export const usePostComment = (channelId: string | undefined) => {
   const queryClient = useQueryClient();
 
   // TODO: [24/1/2] error handling 공통으로 뺼 것
@@ -11,6 +11,7 @@ export const usePostComment = () => {
     mutationFn: createComment,
     onSuccess: (comment) => {
       queryClient.invalidateQueries({ queryKey: threads.threadDetail(comment.post).queryKey });
+      queryClient.invalidateQueries({ queryKey: threads.threadsByChannel(channelId).queryKey });
     },
   });
 };

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -31,6 +31,7 @@ interface Props {
   editorProps: EditorProps;
   onEditClose?: () => void;
   authorNickname?: string;
+  channelId?: string;
 }
 
 const EditorTextArea = ({

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -30,7 +30,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
   const { user } = useGetUserInfo();
   const { thread, isPending } = useGetThread(threadId);
 
-  const { deleteComment } = useDeleteComment(threadId);
+  const { deleteComment } = useDeleteComment({ threadId, channelId: thread?.channel._id });
 
   const handleClickDetailInner = (event: MouseEvent) => {
     event.stopPropagation();
@@ -90,6 +90,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
             isMention={true}
             nickname={thread.nickname}
             editorProps={{
+              channelId: thread.channel._id,
               channelName: thread.channel.name,
               postId: thread._id,
               postAuthorId: thread.author._id,

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -16,15 +16,13 @@ interface PatchThreadProps {
 }
 
 interface CommentProps {
+  channelId: string;
   channelName: string;
   postId: string;
   postAuthorId: string;
 }
 
 export type EditorProps = CreateThreadProps | PatchThreadProps | CommentProps;
-const isCreateThreadProps = (props: EditorProps): props is CreateThreadProps => {
-  return "channelId" in props;
-};
 
 const isPatchThreadProps = (props: EditorProps): props is PatchThreadProps => {
   return "prevContent" in props;
@@ -35,15 +33,15 @@ const isCommentProps = (props: EditorProps): props is CommentProps => {
 };
 
 export const getTypeOfEditor = (props: EditorProps) => {
-  if (isCreateThreadProps(props)) {
-    return "스레드 작성";
+  if (isCommentProps(props)) {
+    return "댓글 작성";
   }
 
   if (isPatchThreadProps(props)) {
     return "스레드 수정";
   }
 
-  return "댓글 작성";
+  return "스레드 작성";
 };
 
 interface Props {
@@ -61,14 +59,14 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
 
   const { uploadThread } = useCreateThread({
     nickname,
-    channelId: isCreateThreadProps(editorProps) ? editorProps.channelId : "",
+    channelId: editorProps.channelId,
     mentionedList,
   });
 
   const { changeThread } = useChangeThread({
     nickname,
     postId: isPatchThreadProps(editorProps) ? editorProps.postId : "",
-    channelId: isPatchThreadProps(editorProps) ? editorProps.channelId : "",
+    channelId: editorProps.channelId,
     mentionedList,
   });
 
@@ -78,18 +76,20 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
     channelName: isCommentProps(editorProps) ? editorProps.channelName : "",
     postAuthorId: isCommentProps(editorProps) ? editorProps.postAuthorId : "",
     mentionedList,
+    channelId: editorProps.channelId,
   });
 
   useEffect(() => {
-    if (isCreateThreadProps(editorProps)) {
-      setUpload(() => uploadThread);
-    }
     if (isPatchThreadProps(editorProps)) {
       setUpload(() => changeThread);
+      return;
     }
     if (isCommentProps(editorProps)) {
       setUpload(() => uploadComment);
+      return;
     }
+
+    setUpload(() => uploadThread);
   }, [editorProps, mentionedList]);
 
   return { upload };

--- a/src/hooks/api/useUploadComment.ts
+++ b/src/hooks/api/useUploadComment.ts
@@ -9,6 +9,7 @@ import { NOTIFICATION_TYPES } from "@/constants/notification";
 interface Props {
   nickname: string | undefined;
   postId: string;
+  channelId: string;
   channelName: string;
   mentionedList?: UserDBProps[];
   postAuthorId: string;
@@ -17,11 +18,12 @@ interface Props {
 const useUploadComment = ({
   nickname,
   postId,
+  channelId,
   channelName,
   mentionedList,
   postAuthorId,
 }: Props) => {
-  const { mutateAsync: commentMutate } = usePostComment();
+  const { mutateAsync: commentMutate } = usePostComment(channelId);
   const { mutate: notificationMutate } = usePostNotification();
   const { mentionNotification } = useMentionNotification({ mentionedList });
 


### PR DESCRIPTION
## 📝 작업 내용

댓글 추가, 삭제시 스레드 상세보기의 query key invalidate 해주고 있어서
리스트의 query key도 invalidate 처리 해주었습니다.

## 💬 리뷰 요구사항

수정사항 있으면 알려주세요!

close #201 
