### PR TITLE
[#215] Fix: GA4 script를 개발 환경에서는 로딩하지 않는 오류 

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,6 @@ import svgr from "vite-plugin-svgr";
 export default ({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
 
-  console.log(process.env);
-
   return defineConfig({
     plugins: [
       react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,33 +1,40 @@
 import { VitePluginRadar } from "vite-plugin-radar";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 
-export default defineConfig({
-  plugins: [
-    react(),
-    svgr({
-      include: "**/*.svg",
-    }),
-    sentryVitePlugin({
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
-      telemetry: false,
-    }),
-    VitePluginRadar({
-      enableDev: false,
-      analytics: {
-        id: process.env.GA4_ID,
-      },
-    }),
-  ],
+export default ({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
 
-  resolve: {
-    alias: [{ find: "@", replacement: "/src" }],
-  },
+  console.log(process.env);
 
-  build: {
-    sourcemap: true,
-  },
-});
+  return defineConfig({
+    plugins: [
+      react(),
+      svgr({
+        include: "**/*.svg",
+      }),
+      sentryVitePlugin({
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+        telemetry: false,
+      }),
+      VitePluginRadar({
+        enableDev: true,
+        analytics: {
+          id: process.env.VITE_GA4_ID,
+          disable: process.env.NODE_ENV !== "production",
+        },
+      }),
+    ],
+
+    resolve: {
+      alias: [{ find: "@", replacement: "/src" }],
+    },
+
+    build: {
+      sourcemap: true,
+    },
+  });
+};


### PR DESCRIPTION
resolves #215 

## 📝 작업 내용

GA4 script를 개발 환경에서는 로딩하지 않는 오류를 해결함

원인
- Vite plugin이 enableDev: false 혹은 GA4 ID가 없는 경우 script를 추가하지 않음

해결 방법
- 환경 변수 이름의 prefix에 `VITE_`를 추가해 env 파일에서 로딩
- 개발 환경에서도 로딩하되 전송만 하지 않게 `disable` 옵션을 배포 환경이 아닐 때 활성화