### PR TITLE
[#218] Fix: 로그인, 내 정보 수정 모달 수정

### DIFF
--- a/src/apis/auth/usePostLogout.ts
+++ b/src/apis/auth/usePostLogout.ts
@@ -14,7 +14,6 @@ const usePostLogout = () => {
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: auth.userInfo(token).queryKey });
       removeLocalStorage("token");
-      removeLocalStorage("isLogin");
       if (location.pathname.includes("my")) location.pathname = "/";
     },
   });

--- a/src/apis/thread/useGetThreads.ts
+++ b/src/apis/thread/useGetThreads.ts
@@ -4,8 +4,6 @@ import { getThreadsByChannelId } from "./queryFn";
 import threads from "./queryKey";
 
 const useGetThreads = (channelId: string | undefined, totalThreads: number) => {
-  console.log(totalThreads);
-
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError, error } =
     useInfiniteQuery({
       queryKey: threads.threadsByChannel(channelId).queryKey,

--- a/src/components/Layout/Modals/Information/index.tsx
+++ b/src/components/Layout/Modals/Information/index.tsx
@@ -24,17 +24,19 @@ const InformationModal = ({ open, close }: Props) => {
           데브코스 간 생긴 일에 대해 익명으로 하고 싶었던 칭찬, 응원, 고해성사를 할 수 있는
           <strong className={titleCSS}> 데나무숲</strong>을 소개합니다.
         </p>
-        <strong className={cn(titleCSS, "block")}>칭찬&응원 게시판 사용법</strong>
+        <strong className={cn(titleCSS, "block")}>칭찬&응원 게시판 이용법</strong>
         <p>
           소중한 사람들을 멘션하여 익명으로 감사 혹은 응원의 마음을 전달해보세요. 본인이 칭찬이나
           응원을 받고 싶을 때도 사용할 수 있습니다!
         </p>
-        <strong className={cn(titleCSS, "block")}>무능 게시판 사용법</strong>
+        <strong className={cn(titleCSS, "block")}>무능 게시판 이용법</strong>
         <p>
           본인이 무능하다고 여겨질 때, 혹은 아무 것도 안(못)해서 죄책감이 생겼을 때, 무능 게시판에서
           고해성사를 통해 답답한 마음을 풀어내보세요.
         </p>
-        <strong className={cn(titleCSS, "block")}>개선 사항 게시판 사용법</strong>
+        <strong className={cn(titleCSS, "block")}>잡담 게시판 이용법</strong>
+        <p>아무 말을 편하게 올려보세요 :D</p>
+        <strong className={cn(titleCSS, "block")}>개선 사항 게시판 이용법</strong>
         <p>원하는 개선사항은 개선사항 채널에 편하게 익명으로 남겨주세요.</p>
         <p className="mt-6 text-center text-sm text-gray-400">
           데나무숲을 만든 사람들이 궁금하다면{" "}

--- a/src/components/Layout/Modals/Login/index.tsx
+++ b/src/components/Layout/Modals/Login/index.tsx
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { AxiosError } from "axios";
 import { useOverlay } from "@toss/use-overlay";
 
 import { Button } from "@/components/ui/button";
@@ -11,12 +10,6 @@ import RegisterModal from "../Register";
 import { LOGIN_FIELDS, LOGIN_FIELDS_SCHEMA } from "./config";
 
 import usePostLogin from "@/apis/auth/usePostLogin";
-import {
-  AUTH_ERROR_MESSAGE,
-  AUTH_ERROR_RESPONSE,
-  AUTH_SUCCESS_MESSAGE,
-} from "@/constants/toastMessage";
-import useToast from "@/hooks/common/useToast";
 
 interface Props {
   open: boolean;
@@ -25,7 +18,6 @@ interface Props {
 
 const LoginModal = ({ open, close }: Props) => {
   const { login } = usePostLogin();
-  const { showPromiseToast } = useToast();
   const { open: openModal } = useOverlay();
 
   const handleRegisterClick = () => {
@@ -36,23 +28,7 @@ const LoginModal = ({ open, close }: Props) => {
   };
 
   const handleSubmit = (loginInfo: z.infer<typeof LOGIN_FIELDS_SCHEMA>) => {
-    showPromiseToast({
-      promise: login(loginInfo),
-      messages: {
-        success: ({ user: { fullName } }) => {
-          close();
-          gtag("event", "retention_로그인");
-          const { nickname } = JSON.parse(fullName);
-          return AUTH_SUCCESS_MESSAGE.LOGIN(nickname);
-        },
-        error: (error: AxiosError) => {
-          if (error?.response?.data === AUTH_ERROR_RESPONSE.LOGIN_FAILED) {
-            return AUTH_ERROR_MESSAGE.LOGIN_FAILED;
-          }
-          return AUTH_ERROR_MESSAGE.SERVER_ERROR;
-        },
-      },
-    });
+    login(loginInfo);
   };
 
   return (

--- a/src/components/Layout/Modals/Profile/index.tsx
+++ b/src/components/Layout/Modals/Profile/index.tsx
@@ -83,7 +83,7 @@ const ProfileModal = ({ open, close }: Props) => {
         open,
         onOpenChange: close,
       }}
-      title="내 프로필 편집"
+      title="내 정보 수정"
     >
       <SimpleBaseForm
         fields={PROFILE_FIELDS}

--- a/src/components/Layout/Sidebar/view.tsx
+++ b/src/components/Layout/Sidebar/view.tsx
@@ -6,7 +6,7 @@ import { useOverlay } from "@toss/use-overlay";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
-import { getLocalStorage, setLocalStorage } from "@/utils/localStorage";
+import { getLocalStorage } from "@/utils/localStorage";
 
 import LoginModal from "../Modals/Login";
 import ProfileModal from "../Modals/Profile";
@@ -53,14 +53,11 @@ export const SidebarView = ({ pathname, user, hasNewNotification, theme }: Props
   const { open } = useOverlay();
 
   const isLoggedIn = !!getLocalStorage("token", "");
-  const alreadyLoggedIn = getLocalStorage("isLogin", false);
 
   useEffect(() => {
     if (!isLoggedIn) return;
-
-    if (!alreadyLoggedIn) setLocalStorage("isLogin", true);
-    else toast.success("자동 로그인 되었습니다 :D");
-  }, [isLoggedIn, alreadyLoggedIn]);
+    toast.success(AUTH_SUCCESS_MESSAGE.LOGIN(nickname));
+  }, [isLoggedIn]);
 
   const handleLoginModalOpen = () => {
     open(({ isOpen, close }) => {


### PR DESCRIPTION
## 📝 작업 내용

내 정보 수정과 내 프로필 편집 문구 통일이 안되어있음 
> 내 정보 수정으로 통일했습니다

로그인 후 강제 새로고침이 되어 로그인이 되었습니다 메시지가 무시당하고 바로 자동로그인 되었습니다 메시지가 뜸
> 로그인 후 나오는 성공 메시지는 삭제하고 새로고침 후 자동 로그인 말고 로그인 되었습니다 메시지만 노출되게 수정

안내 모달에 잡담 게시판 설명 추가

사용 > 이용으로 단어 통일

close #218
