### PR TITLE
[#226] Fix: 댓글 추가, 삭제시 ui 반영 속도 개선

### DIFF
--- a/src/apis/comment/useDeleteComment.ts
+++ b/src/apis/comment/useDeleteComment.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { Comment, Thread } from "@/types/thread";
+
 import { deleteComment } from "@/apis/comment/queryFn.ts";
 import threads from "@/apis/thread/queryKey.ts";
 
@@ -13,7 +15,7 @@ const useDeleteComment = ({ threadId, channelId }: Parameters) => {
 
   const { mutate, ...props } = useMutation({
     mutationFn: deleteComment,
-    onSuccess: () => {
+    onSuccess: (deletedComment: Comment) => {
       queryClient.invalidateQueries({
         queryKey: threads.threadDetail(threadId).queryKey,
       });
@@ -21,6 +23,32 @@ const useDeleteComment = ({ threadId, channelId }: Parameters) => {
       queryClient.invalidateQueries({
         queryKey: threads.threadsByChannel(channelId).queryKey,
       });
+
+      queryClient.setQueryData(threads.threadDetail(threadId).queryKey, (threadDetail: Thread) => ({
+        ...threadDetail,
+        comments: threadDetail.comments.filter((comment) => comment._id !== deletedComment._id),
+      }));
+
+      queryClient.setQueryData(
+        threads.threadsByChannel(channelId).queryKey,
+        ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
+          return {
+            pages: pages.map((page) =>
+              page.map((thread) =>
+                thread._id === deletedComment.post
+                  ? {
+                      ...thread,
+                      comments: thread.comments.filter(
+                        (comment) => comment._id !== deletedComment._id,
+                      ),
+                    }
+                  : thread,
+              ),
+            ),
+            pageParams,
+          };
+        },
+      );
     },
   });
 

--- a/src/apis/comment/useDeleteComment.ts
+++ b/src/apis/comment/useDeleteComment.ts
@@ -16,14 +16,6 @@ const useDeleteComment = ({ threadId, channelId }: Parameters) => {
   const { mutate, ...props } = useMutation({
     mutationFn: deleteComment,
     onSuccess: (deletedComment: Comment) => {
-      queryClient.invalidateQueries({
-        queryKey: threads.threadDetail(threadId).queryKey,
-      });
-
-      queryClient.invalidateQueries({
-        queryKey: threads.threadsByChannel(channelId).queryKey,
-      });
-
       queryClient.setQueryData(threads.threadDetail(threadId).queryKey, (threadDetail: Thread) => ({
         ...threadDetail,
         comments: threadDetail.comments.filter((comment) => comment._id !== deletedComment._id),
@@ -48,6 +40,14 @@ const useDeleteComment = ({ threadId, channelId }: Parameters) => {
           return { pages: updatedPages, pageParams };
         },
       );
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadDetail(threadId).queryKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadsByChannel(channelId).queryKey,
+      });
     },
   });
 

--- a/src/apis/comment/useDeleteComment.ts
+++ b/src/apis/comment/useDeleteComment.ts
@@ -32,21 +32,20 @@ const useDeleteComment = ({ threadId, channelId }: Parameters) => {
       queryClient.setQueryData(
         threads.threadsByChannel(channelId).queryKey,
         ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
-          return {
-            pages: pages.map((page) =>
-              page.map((thread) =>
-                thread._id === deletedComment.post
-                  ? {
-                      ...thread,
-                      comments: thread.comments.filter(
-                        (comment) => comment._id !== deletedComment._id,
-                      ),
-                    }
-                  : thread,
-              ),
+          const updatedPages = pages.map((page) =>
+            page.map((thread) =>
+              thread._id === deletedComment.post
+                ? {
+                    ...thread,
+                    comments: thread.comments.filter(
+                      (comment) => comment._id !== deletedComment._id,
+                    ),
+                  }
+                : thread,
             ),
-            pageParams,
-          };
+          );
+
+          return { pages: updatedPages, pageParams };
         },
       );
     },

--- a/src/apis/comment/usePostComment.ts
+++ b/src/apis/comment/usePostComment.ts
@@ -12,9 +12,6 @@ export const usePostComment = (channelId: string | undefined) => {
   return useMutation({
     mutationFn: createComment,
     onSuccess: (comment) => {
-      queryClient.invalidateQueries({ queryKey: threads.threadDetail(comment.post).queryKey });
-      queryClient.invalidateQueries({ queryKey: threads.threadsByChannel(channelId).queryKey });
-
       queryClient.setQueryData(
         threads.threadDetail(comment.post).queryKey,
         (threadDetail: Thread) => ({
@@ -37,6 +34,9 @@ export const usePostComment = (channelId: string | undefined) => {
           return { pages: updatedPages, pageParams };
         },
       );
+
+      queryClient.invalidateQueries({ queryKey: threads.threadDetail(comment.post).queryKey });
+      queryClient.invalidateQueries({ queryKey: threads.threadsByChannel(channelId).queryKey });
     },
   });
 };

--- a/src/apis/comment/usePostComment.ts
+++ b/src/apis/comment/usePostComment.ts
@@ -26,19 +26,15 @@ export const usePostComment = (channelId: string | undefined) => {
       queryClient.setQueryData(
         threads.threadsByChannel(channelId).queryKey,
         ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
-          return {
-            pages: pages.map((page) =>
-              page.map((thread) =>
-                thread._id === comment.post
-                  ? {
-                      ...thread,
-                      comments: [...thread.comments, comment],
-                    }
-                  : thread,
-              ),
+          const updatedPages = pages.map((page) =>
+            page.map((thread) =>
+              thread._id === comment.post
+                ? { ...thread, comments: [...thread.comments, comment] }
+                : thread,
             ),
-            pageParams,
-          };
+          );
+
+          return { pages: updatedPages, pageParams };
         },
       );
     },

--- a/src/components/common/thread/CommentListItem.tsx
+++ b/src/components/common/thread/CommentListItem.tsx
@@ -8,6 +8,7 @@ import { parseTitleOrComment } from "@/utils/parsingJson";
 import { Comment } from "@/types/thread";
 
 import { ANONYMOUS_NICKNAME, DEFAULT_PROFILE } from "@/constants/commonConstants";
+import useToast from "@/hooks/common/useToast";
 
 interface Props {
   commentInfo: Comment;
@@ -24,8 +25,15 @@ const CommentListItem = ({ commentInfo, onClose, isAuthor, profileImage }: Props
   const { createdAt, comment, _id } = commentInfo;
   const { content, nickname, mentionedList } = parseTitleOrComment(comment);
 
+  const { showToast } = useToast();
+
   const handleClick = () => {
     onClose(_id);
+
+    showToast({
+      message: "댓글을 삭제 중입니다.",
+      duration: 800,
+    });
   };
 
   return (

--- a/src/components/common/thread/ThreadListItem.tsx
+++ b/src/components/common/thread/ThreadListItem.tsx
@@ -115,7 +115,7 @@ const ThreadListItem = ({ thread, channelId, isThreadDetail, onClick }: Props) =
               }
               alt="프로필"
             />
-            <AvatarFallback>{author?.nickname.charAt(0)}</AvatarFallback>
+            <AvatarFallback>{author?.nickname?.charAt(0)}</AvatarFallback>
           </Avatar>
           <div className="min-w-0 flex-grow">
             <div className="flex justify-between">

--- a/src/hooks/common/useToast.ts
+++ b/src/hooks/common/useToast.ts
@@ -6,8 +6,8 @@ import { LOADING_MESSAGE } from "@/constants/toastMessage";
 interface ToastParameters {
   message: string;
   duration?: number;
-  actionLabel: string;
-  onActionClick: () => void;
+  actionLabel?: string;
+  onActionClick?: () => void;
 }
 
 interface PromiseToastParameters<T> {
@@ -18,17 +18,28 @@ interface PromiseToastParameters<T> {
   };
 }
 
+interface ToastOptions {
+  duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
 const useToast = () => {
   const showToast = ({ message, duration = 2000, actionLabel, onActionClick }: ToastParameters) => {
-    toast(message, {
-      action: actionLabel
-        ? {
-            label: actionLabel,
-            onClick: onActionClick,
-          }
-        : undefined,
+    const toastOptions: ToastOptions = {
       duration,
-    });
+    };
+
+    if (actionLabel && onActionClick) {
+      toastOptions.action = {
+        label: actionLabel,
+        onClick: onActionClick,
+      };
+    }
+
+    toast(message, toastOptions);
   };
 
   const showPromiseToast = <T>({ promise, messages }: PromiseToastParameters<T>) => {


### PR DESCRIPTION
## 📝 작업 내용

저희 프로젝트의 특이점은 스레드 작성, 스레드 리스트, 스레드 상세보기를 한 화면에서 볼 수 있다는 것입니다. 따라서, 댓글이 추가될때 상세화면만 반영이 이루어져야 하는 것이 아니라 스레드 리스트 부분에도 변경이 일어나야 합니다.

그러다보니, 하나의 작업임에도 두 개의 쿼리 키를 invalidate하여 새로 데이터를 받아와야 합니다. 기존에는 댓글 작성 및 삭제시 성공했을때 스레드 리스트의 쿼리 키와 스레드 상세의 쿼리 키를 invalidate 처리만 해주고, 재요청 받은 데이터를 UI에 반영합니다.

스레드 상세의 요청의 경우 속도가 크게 느리지는 않지만 문제는 스레드 리스트의 경우입니다. 이 경우 불러오는 리스트의 양이 많다보니 시간이 오래 걸리게 되는데, slow 3G 환경의 경우 최대 10초가 넘는 시간을 기다려야 UI에 반영이 되었습니다.

아래 영상을 보시면 10.61초가 걸린 후에야 스레드 리스트 쪽에 변경이 일어난 것을 알 수 있습니다. 현재 저희 프로젝트는 timeout을 10초로 제한해두었는데, 지금처럼 10초가 넘어가게 되면 한 번 더 요청이 가므로 최악의 경우 10초 이상의 시간이 걸립니다.

https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/138ebc16-579a-425c-ad54-f5d46f52106f

따라서, react query의 setQueryData를 사용하여 요청이 성공하게 되면 수동으로 데이터를 변경해주어 쿼리 키가 invalidate 되고 요청을 받아오지 않아도 되게끔 변경해주었습니다.

아래는 slow 3G 환경에서 setQueryData로 데이터를 바로 반영하게 된 영상입니다.

https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/a5e56af4-d611-4eeb-9ee3-790bedee0534

영상을 보시면 알 수 있듯, invalidate된 쿼리 키 요청을 기다리지 않고 댓글 작성이 성공한 시간인 2.16초 만에 UI가 반영되었습니다.

아래는 no-throttling 환경에서 개선 전, 실험한 영상입니다. 

https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/d5cf2cc7-6c26-4882-b8c3-4aa601772573

스레드 리스트의 경우 897ms가 지난 후에 반영이 이루어집니다. 아래는 개선 후의 실험 영상입니다.

https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/fa206ad4-3b5d-451f-8780-8f16d14752a1

스레드 리스트와 스레드 상세 모두 요청이 성공한 시간인 86ms만에 UI 반영이 됩니다.

<hr />

그럼, 평균적으로 얼마만의 시간만큼 UI에 더 빠르게 적용했는지 계산해보겠습니다.

1. slow 3G
slow 3G 환경에서 개선 전 세 경우의 평균 시간은 10.69초, 개선 후 평균 시간은 2.1566초로 약 79.83%의 개선 효과가 있었습니다.
<img width="1315" alt="slow3g_1" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/e6fa9c25-d65e-4da7-8a08-949e1b9ae5ea">
<img width="1313" alt="slow3g_2" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/aef54163-1536-486f-b500-be502bce9f70">
<img width="1317" alt="slow3g_3" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/6f7b2257-f8d4-4abc-8cbf-3f3f2eb8f712">


2. no-throttling
no-throttling 환경에서 개선 전 세 경우의 평균 시간은 770ms, 개선 후 세 경우의 평균 시간은 78ms로 약 89.87%의 개선 효과가 있었습니다.
<img width="984" alt="nothrottle_1" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/ed9abb96-278d-471d-af02-9a02fff6979f">
<img width="968" alt="nothrottle_2" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/8f17c0b2-359d-43f0-acf5-b33f667e98fb">
<img width="969" alt="notrottle_3" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/c3330a09-806a-42eb-a076-67ee02fdc2b1">


<hr />
댓글 삭제의 경우도 비슷하나, 댓글 삭제의 경우는 setQueryData`에서 filter구문을 사용하고 있기 때문에 개선을 하더라도 반영까지 조금 더 시간이 걸렸습니다. 따라서 댓글 삭제시에는 토스트를 띄워 댓글이 삭제중이라는 것을 유저에게 알렸습니다.

<img width="1774" alt="스크린샷 2024-01-18 오후 7 34 44" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/50647541-f5a4-4b4b-bc53-a8e2d9d9e6cc">


## 💬 리뷰 요구사항

잘못된 점이 있다면 알려주시면 감사하겠습니다 : )

close #226 
