### PR TITLE
[#228] Fix: 스레드 작성 및 삭제시 UI 즉시 업데이트

### DIFF
--- a/src/apis/thread/useDeleteThread.ts
+++ b/src/apis/thread/useDeleteThread.ts
@@ -11,10 +11,6 @@ const useDeleteThread = (channelId: string) => {
   const { mutate, ...rest } = useMutation({
     mutationFn: deleteThread,
     onSuccess: (deleteThread: Thread) => {
-      queryClient.invalidateQueries({
-        queryKey: threads.threadsByChannel(channelId).queryKey,
-      });
-
       queryClient.setQueryData(
         threads.threadsByChannel(channelId).queryKey,
         ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
@@ -26,6 +22,10 @@ const useDeleteThread = (channelId: string) => {
           };
         },
       );
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadsByChannel(channelId).queryKey,
+      });
     },
   });
 

--- a/src/apis/thread/useDeleteThread.ts
+++ b/src/apis/thread/useDeleteThread.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { Thread } from "@/types/thread";
+
 import { deleteThread } from "@/apis/thread/queryFn.ts";
 import threads from "@/apis/thread/queryKey.ts";
 
@@ -8,10 +10,22 @@ const useDeleteThread = (channelId: string) => {
 
   const { mutate, ...rest } = useMutation({
     mutationFn: deleteThread,
-    onSuccess: () => {
+    onSuccess: (deleteThread: Thread) => {
       queryClient.invalidateQueries({
         queryKey: threads.threadsByChannel(channelId).queryKey,
       });
+
+      queryClient.setQueryData(
+        threads.threadsByChannel(channelId).queryKey,
+        ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
+          const updatedPages = pages[0].filter((thread) => thread._id !== deleteThread._id);
+
+          return {
+            pages: [updatedPages],
+            pageParams,
+          };
+        },
+      );
     },
   });
 

--- a/src/apis/thread/usePostThread.ts
+++ b/src/apis/thread/usePostThread.ts
@@ -38,7 +38,6 @@ export const usePostThread = (channelId: string) => {
         threads.threadsByChannel(channelId).queryKey,
         ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
           const updatedPages = [[parsedPostedThread, ...pages[0]]];
-          console.log(pages, postedThread);
 
           return { pages: updatedPages, pageParams };
         },

--- a/src/apis/thread/usePostThread.ts
+++ b/src/apis/thread/usePostThread.ts
@@ -30,10 +30,6 @@ export const usePostThread = (channelId: string) => {
         },
       };
 
-      queryClient.invalidateQueries({
-        queryKey: threads.threadsByChannel(channelId).queryKey,
-      });
-
       queryClient.setQueryData(
         threads.threadsByChannel(channelId).queryKey,
         ({ pages, pageParams }: { pages: Thread[][]; pageParams: number[] }) => {
@@ -42,6 +38,10 @@ export const usePostThread = (channelId: string) => {
           return { pages: updatedPages, pageParams };
         },
       );
+
+      queryClient.invalidateQueries({
+        queryKey: threads.threadsByChannel(channelId).queryKey,
+      });
     },
   });
 };


### PR DESCRIPTION
## 📝 작업 내용

api 응답 속도가 느려, 요청 성공시 응답을 기다리지 않고 setQueryData로 즉시 변경했습니다.
앞서, 댓글의 경우 반영 속도가 느려 토스트를 띄워줬었는데 스레드의 경우 반영 속도가 빨라 토스트를 따로 띄우지 않았습니다.
그런데 삭제의 경우, 모달을 한 번 띄워주는게 좋을 것 같다는 생각이 드네요.
슬랙의 경우 삭제 버튼의 접근이 어렵지만 저희는 마우스를 호버하면 삭제 버튼이 바로 노출되기 때문에 모달로 인지시켜주는게 좋을 것 같습니다.

## 💬 리뷰 요구사항

onSuccess로 넘어오는 데이터는 파싱되기 전, 서버 응답 값이더라구요. 때문에 `onSuccess`에서 데이터를 파싱하는 로직이 중복으로 들어가게 되었습니다.

이렇게 되다보니 전에 재훈님 말씀처럼 axios interceptors에서 파싱하는 방법이 더 좋을 것 같다는 생각이 듭니다.

많은 의견 주시면 감사하겠습니다!

close #228 
