### PR TITLE
[#230] Style: 스레드 리스트, 상세보기 요청 실패시 보이는 에러 컴포넌트 구현 및 적용

### DIFF
--- a/src/apis/thread/useGetThreads.ts
+++ b/src/apis/thread/useGetThreads.ts
@@ -4,22 +4,30 @@ import { getThreadsByChannelId } from "./queryFn";
 import threads from "./queryKey";
 
 const useGetThreads = (channelId: string | undefined, totalThreads: number) => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError, error } =
-    useInfiniteQuery({
-      queryKey: threads.threadsByChannel(channelId).queryKey,
-      queryFn: channelId
-        ? ({ pageParam = 0 }) => getThreadsByChannelId(channelId, pageParam)
-        : undefined,
-      enabled: !!channelId && !!totalThreads,
-      getNextPageParam: (lastPage) => {
-        if (!lastPage[0]) return;
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+    error,
+    ...rest
+  } = useInfiniteQuery({
+    queryKey: threads.threadsByChannel(channelId).queryKey,
+    queryFn: channelId
+      ? ({ pageParam = 0 }) => getThreadsByChannelId(channelId, pageParam)
+      : undefined,
+    enabled: !!channelId && !!totalThreads,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage[0]) return;
 
-        const nextPageOffset = lastPage[0].nextPage;
-        if (nextPageOffset > totalThreads) return undefined;
-        return nextPageOffset;
-      },
-      initialPageParam: 0,
-    });
+      const nextPageOffset = lastPage[0].nextPage;
+      if (nextPageOffset > totalThreads) return undefined;
+      return nextPageOffset;
+    },
+    initialPageParam: 0,
+  });
 
   return {
     threads: data?.pages.flatMap((page) => page),
@@ -29,6 +37,7 @@ const useGetThreads = (channelId: string | undefined, totalThreads: number) => {
     isPending,
     isError,
     error,
+    ...rest,
   };
 };
 

--- a/src/components/Error/ApiError.tsx
+++ b/src/components/Error/ApiError.tsx
@@ -7,7 +7,7 @@ interface Props {
   className?: string;
 }
 
-const ThreadError = ({ refetch, className }: Props) => {
+const ApiError = ({ refetch, className }: Props) => {
   return (
     <div className={cn("flex w-full items-center justify-center text-center", className)}>
       <div>
@@ -21,4 +21,4 @@ const ThreadError = ({ refetch, className }: Props) => {
   );
 };
 
-export default ThreadError;
+export default ApiError;

--- a/src/components/Error/thread/ThreadError.tsx
+++ b/src/components/Error/thread/ThreadError.tsx
@@ -1,0 +1,24 @@
+import { RotateCw } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface Props {
+  refetch: () => void;
+  className?: string;
+}
+
+const ThreadError = ({ refetch, className }: Props) => {
+  return (
+    <div className={cn("flex w-full items-center justify-center text-center", className)}>
+      <div>
+        <span className="block">데이터를 불러오는 중 에러가 발생했습니다.</span>
+        <span className="block">새로 고침을 눌러 다시 시도해주세요.</span>
+        <div className="mt-2 flex cursor-pointer justify-center" onClick={refetch}>
+          <RotateCw />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ThreadError;

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -12,7 +12,7 @@ import useGetUserInfo from "@/apis/auth/useGetUserInfo.ts";
 import useDeleteComment from "@/apis/comment/useDeleteComment.ts";
 import CommentListItemSkeleton from "@/components/Skelton/CommentListItemSkeleton";
 import ThreadDetailItemSkeleton from "@/components/Skelton/ThreaDetailItemSkeleton";
-import ThreadError from "@/components/Error/thread/ThreadError";
+import ApiError from "@/components/Error/ApiError";
 
 interface Props {
   threadId: string | undefined;
@@ -51,7 +51,7 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
         className,
       )}
     >
-      {isError && <ThreadError refetch={refetch} className="h-full" />}
+      {isError && <ApiError refetch={refetch} className="h-full" />}
       {!isError && (
         <div>
           <div className="flex items-center justify-between p-2">

--- a/src/components/common/thread/ThreadDetailView.tsx
+++ b/src/components/common/thread/ThreadDetailView.tsx
@@ -12,6 +12,7 @@ import useGetUserInfo from "@/apis/auth/useGetUserInfo.ts";
 import useDeleteComment from "@/apis/comment/useDeleteComment.ts";
 import CommentListItemSkeleton from "@/components/Skelton/CommentListItemSkeleton";
 import ThreadDetailItemSkeleton from "@/components/Skelton/ThreaDetailItemSkeleton";
+import ThreadError from "@/components/Error/thread/ThreadError";
 
 interface Props {
   threadId: string | undefined;
@@ -30,7 +31,7 @@ const channelMap = {
 
 const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
   const { user } = useGetUserInfo();
-  const { thread, isPending } = useGetThread(threadId);
+  const { thread, isPending, isError, refetch } = useGetThread(threadId);
 
   const { deleteComment } = useDeleteComment({ threadId, channelId: thread?.channel._id });
 
@@ -50,56 +51,63 @@ const ThreadDetailView = ({ threadId, onClose, className }: Props) => {
         className,
       )}
     >
-      <div className="flex items-center justify-between p-2">
-        <div className="flex items-center gap-2">
-          <h2 className="text-2xl font-bold text-content-3">스레드</h2>
+      {isError && <ThreadError refetch={refetch} className="h-full" />}
+      {!isError && (
+        <div>
+          <div className="flex items-center justify-between p-2">
+            <div className="flex items-center gap-2">
+              <h2 className="text-2xl font-bold text-content-3">스레드</h2>
+              {thread && (
+                <p className="text-sm text-content-1">#{channelMap[thread.channel?.name]}게시판</p>
+              )}
+            </div>
+            <button onClick={onClose}>
+              <XIcon className="text-content-1" />
+            </button>
+          </div>
+          {isPending && <ThreadDetailItemSkeleton />}
           {thread && (
-            <p className="text-sm text-content-1">#{channelMap[thread.channel?.name]}게시판</p>
+            <ThreadListItem thread={thread} channelId={thread.channel?._id} isThreadDetail={true} />
           )}
-        </div>
-        <button onClick={onClose}>
-          <XIcon className="text-content-1" />
-        </button>
-      </div>
-      {isPending && <ThreadDetailItemSkeleton />}
-      {thread && (
-        <ThreadListItem thread={thread} channelId={thread.channel?._id} isThreadDetail={true} />
-      )}
-      <div className="mx-2 flex items-center gap-2">
-        <span className="text-content-1">{thread?.comments?.length}개의 댓글</span>
-        <hr className="h-0 flex-1 border-0 border-b-[1px] border-layer-6" />
-      </div>
+          <div className="mx-2 flex items-center gap-2">
+            <span className="text-content-1">{thread?.comments?.length}개의 댓글</span>
+            <hr className="h-0 flex-1 border-0 border-b-[1px] border-layer-6" />
+          </div>
 
-      <div className="mb-4">
-        <ol className="flex flex-col gap-4">
-          {isPending && <CommentListItemSkeleton commentsCount={thread?.comments.length || 2} />}
-          {thread &&
-            thread.comments?.map((comment) => (
-              <CommentListItem
-                key={comment._id}
-                commentInfo={comment}
-                onClose={handleDeleteComment}
-                isAuthor={comment.author._id === user?._id}
-                profileImage={comment.author.image}
+          <div className="mb-4">
+            <ol className="flex flex-col gap-4">
+              {isPending && (
+                <CommentListItemSkeleton commentsCount={thread?.comments.length || 2} />
+              )}
+              {thread &&
+                thread.comments?.map((comment) => (
+                  <CommentListItem
+                    key={comment._id}
+                    commentInfo={comment}
+                    onClose={handleDeleteComment}
+                    isAuthor={comment.author._id === user?._id}
+                    profileImage={comment.author.image}
+                  />
+                ))}
+            </ol>
+          </div>
+
+          <div className="w-full pl-2 pr-2">
+            {thread && (
+              <EditorTextArea
+                isMention={true}
+                nickname={thread.nickname}
+                editorProps={{
+                  channelId: thread.channel._id,
+                  channelName: thread.channel.name,
+                  postId: thread._id,
+                  postAuthorId: thread.author?._id,
+                }}
               />
-            ))}
-        </ol>
-      </div>
-
-      <div className="w-full pl-2 pr-2">
-        {thread && (
-          <EditorTextArea
-            isMention={true}
-            nickname={thread.nickname}
-            editorProps={{
-              channelId: thread.channel._id,
-              channelName: thread.channel.name,
-              postId: thread._id,
-              postAuthorId: thread.author?._id,
-            }}
-          />
-        )}
-      </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/hooks/api/useThreadsByChannel.ts
+++ b/src/hooks/api/useThreadsByChannel.ts
@@ -23,6 +23,7 @@ const useThreadsByChannel = () => {
     isThreadsPending: threadsQuery.isPending,
     isThreadsError: threadsQuery.isError,
     threadsError: threadsQuery.error,
+    refetch: threadsQuery.refetch,
   };
 };
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -11,6 +11,7 @@ import EditorTextArea from "@/components/common/EditorTextArea";
 import ThreadListSkeleton from "@/components/Skelton/ThreadListSkeleton";
 import useThreadsByChannel from "@/hooks/api/useThreadsByChannel";
 import { cn } from "@/lib/utils";
+import ThreadError from "@/components/Error/thread/ThreadError";
 
 const HomePage = () => {
   const {
@@ -21,6 +22,8 @@ const HomePage = () => {
     channelId,
     channelName,
     isThreadsPending,
+    isThreadsError,
+    refetch,
   } = useThreadsByChannel();
 
   const { user } = useGetUserInfo();
@@ -55,6 +58,9 @@ const HomePage = () => {
                 <EmptyThread className="min-h-[calc(100vh-300px)] w-full" />
               )}
             </div>
+            {isThreadsError && (
+              <ThreadError refetch={refetch} className="min-h-[calc(100vh-300px)]" />
+            )}
             {threads && threads?.length !== 0 && (
               <ThreadList
                 threads={threads}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -11,7 +11,7 @@ import EditorTextArea from "@/components/common/EditorTextArea";
 import ThreadListSkeleton from "@/components/Skelton/ThreadListSkeleton";
 import useThreadsByChannel from "@/hooks/api/useThreadsByChannel";
 import { cn } from "@/lib/utils";
-import ThreadError from "@/components/Error/thread/ThreadError";
+import ApiError from "@/components/Error/ApiError";
 
 const HomePage = () => {
   const {
@@ -58,9 +58,7 @@ const HomePage = () => {
                 <EmptyThread className="min-h-[calc(100vh-300px)] w-full" />
               )}
             </div>
-            {isThreadsError && (
-              <ThreadError refetch={refetch} className="min-h-[calc(100vh-300px)]" />
-            )}
+            {isThreadsError && <ApiError refetch={refetch} className="min-h-[calc(100vh-300px)]" />}
             {threads && threads?.length !== 0 && (
               <ThreadList
                 threads={threads}


### PR DESCRIPTION
## 📝 작업 내용

1. ApiError 컴포넌트 UI 작업
처음에 스레드쪽에서만 사용하려고 컴포넌트 이름을 `ThreadError`라고 지었다가, 모든 api 요청 실패 경우에 사용할 수 있을 것 같아 `ApiError`로 변경했습니다. 좋은 이름인지는 잘 모르겠습니다. 추천해주시면 좋을 것 같아요.

2. ThreadList와 ThreadDetailView에 적용
만들어든 컴포넌트를 두 곳에 적용했습니다. refetch는 필수로 받아 아이콘 클릭시 다시 호출하도록 구현했습니다.

### 📷 스크린샷
<img width="1792" alt="스크린샷 2024-01-19 오전 2 06 54" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/5ec7b430-f66a-48eb-a829-b594fe3eda5d">
<img width="1792" alt="스크린샷 2024-01-19 오전 2 07 25" src="https://github.com/prgrms-fe-devcourse/FEDC5_DevNamu_eunsu/assets/61978339/ba7ec7c0-8e90-4a25-9431-b07bc2ba5c1f">


## 💬 리뷰 요구사항

객관적으로 이쁜 UI는 아니에요! 뭔가 이뻐질 수 있는 좋은 아이디어 받습니다~~
추가로 컴포넌트 이름이 `ApiError`가 최선인가에 대한 생각이 계속 들어요. 적절한 이름 추천해주시면 감사하겠습니다.

close #230 
