### PR TITLE
[#232] Modify: useMetionNotification에서 mentionList 의존성 제거

### DIFF
--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -76,7 +76,8 @@ const EditorTextArea = ({
       });
       return;
     }
-    upload(formValues);
+
+    upload({ formValues, mentionedList });
     setMentionedList([]);
     setValue("content", "");
     onEditClose?.();

--- a/src/components/common/EditorTextArea.tsx
+++ b/src/components/common/EditorTextArea.tsx
@@ -50,7 +50,6 @@ const EditorTextArea = ({
   const { upload } = useEditorLogicByProps({
     editorProps,
     nickname: user?.nickname || nickname,
-    mentionedList: mentionedList.length ? mentionedList : undefined,
   });
 
   const { register, handleSubmit, watch, setValue, getValues } = useForm({

--- a/src/hooks/api/useChangeThread.ts
+++ b/src/hooks/api/useChangeThread.ts
@@ -1,22 +1,20 @@
 import usePutThread from "@/apis/thread/usePutThread.ts";
-import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
-import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
 import usePostSlackMessage from "@/apis/slackBot/usePostSlackMessage.ts";
+import { FormSubmitProps } from "@/hooks/api/useCreateThread.ts";
 
 interface Props {
   nickname: string | undefined;
   postId: string;
   channelId: string;
-  mentionedList?: UserDBProps[];
 }
-const useChangeThread = ({ nickname, postId, channelId, mentionedList }: Props) => {
+const useChangeThread = ({ nickname, postId, channelId }: Props) => {
   const { mutateAsync: patchThreadMutate } = usePutThread();
-  const { mentionNotification } = useMentionNotification({ mentionedList });
+  const { mentionNotification } = useMentionNotification();
   const { sendMessageBySlackBot } = usePostSlackMessage();
 
-  const changeThread = async (formValues: FormValues) => {
+  const changeThread = async ({ formValues, mentionedList }: FormSubmitProps) => {
     if (!formValues) return;
 
     const threadRequest = {

--- a/src/hooks/api/useCreateThread.ts
+++ b/src/hooks/api/useCreateThread.ts
@@ -3,6 +3,7 @@ import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
+import usePostSlackMessage from "@/apis/slackBot/usePostSlackMessage.ts";
 
 interface Props {
   nickname: string | undefined;
@@ -17,7 +18,7 @@ export interface FormSubmitProps {
 const useCreateThread = ({ nickname, channelId }: Props) => {
   const { mutateAsync: createThreadMutate } = usePostThread(channelId);
   const { mentionNotification } = useMentionNotification();
-  // const { sendMessageBySlackBot } = usePostSlackMessage();
+  const { sendMessageBySlackBot } = usePostSlackMessage();
   const uploadThread = async ({ formValues, mentionedList }: FormSubmitProps) => {
     if (!formValues) return;
 
@@ -38,7 +39,7 @@ const useCreateThread = ({ nickname, channelId }: Props) => {
       channelName: threadResponse.channel.name,
     });
 
-    // sendMessageBySlackBot({ mentionedList });
+    sendMessageBySlackBot({ mentionedList });
   };
   return { uploadThread };
 };

--- a/src/hooks/api/useCreateThread.ts
+++ b/src/hooks/api/useCreateThread.ts
@@ -3,18 +3,22 @@ import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
-import usePostSlackMessage from "@/apis/slackBot/usePostSlackMessage.ts";
 
 interface Props {
   nickname: string | undefined;
   channelId: string;
+}
+
+export interface FormSubmitProps {
+  formValues: FormValues;
   mentionedList?: UserDBProps[];
 }
-const useCreateThread = ({ nickname, channelId, mentionedList }: Props) => {
+
+const useCreateThread = ({ nickname, channelId }: Props) => {
   const { mutateAsync: createThreadMutate } = usePostThread(channelId);
-  const { mentionNotification } = useMentionNotification({ mentionedList });
-  const { sendMessageBySlackBot } = usePostSlackMessage();
-  const uploadThread = async (formValues: FormValues) => {
+  const { mentionNotification } = useMentionNotification();
+  // const { sendMessageBySlackBot } = usePostSlackMessage();
+  const uploadThread = async ({ formValues, mentionedList }: FormSubmitProps) => {
     if (!formValues) return;
 
     const threadRequest = {
@@ -28,12 +32,13 @@ const useCreateThread = ({ nickname, channelId, mentionedList }: Props) => {
     if (!mentionedList) return;
 
     mentionNotification({
+      mentionedList,
       content: formValues.content,
       postId: threadResponse._id,
       channelName: threadResponse.channel.name,
     });
 
-    sendMessageBySlackBot({ mentionedList });
+    // sendMessageBySlackBot({ mentionedList });
   };
   return { uploadThread };
 };

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import useCreateThread from "@/hooks/api/useCreateThread.ts";
+import useCreateThread, { FormSubmitProps } from "@/hooks/api/useCreateThread.ts";
 import useChangeThread from "@/hooks/api/useChangeThread.ts";
 import useUploadComment from "@/hooks/api/useUploadComment.ts";
 import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
@@ -51,7 +51,7 @@ interface Props {
 }
 
 interface UploadHooksProps {
-  (params: { anonymous: boolean; content: string }): void;
+  (params: FormSubmitProps): void;
 }
 
 const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) => {
@@ -60,14 +60,12 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
   const { uploadThread } = useCreateThread({
     nickname,
     channelId: editorProps.channelId,
-    mentionedList,
   });
 
   const { changeThread } = useChangeThread({
     nickname,
     postId: isPatchThreadProps(editorProps) ? editorProps.postId : "",
     channelId: editorProps.channelId,
-    mentionedList,
   });
 
   const { uploadComment } = useUploadComment({
@@ -75,7 +73,6 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
     postId: isCommentProps(editorProps) ? editorProps.postId : "",
     channelName: isCommentProps(editorProps) ? editorProps.channelName : "",
     postAuthorId: isCommentProps(editorProps) ? editorProps.postAuthorId : "",
-    mentionedList,
     channelId: editorProps.channelId,
   });
 

--- a/src/hooks/api/useEditorLogicByProps.ts
+++ b/src/hooks/api/useEditorLogicByProps.ts
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import useCreateThread, { FormSubmitProps } from "@/hooks/api/useCreateThread.ts";
 import useChangeThread from "@/hooks/api/useChangeThread.ts";
 import useUploadComment from "@/hooks/api/useUploadComment.ts";
-import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 
 interface CreateThreadProps {
   channelId: string;
@@ -47,14 +46,13 @@ export const getTypeOfEditor = (props: EditorProps) => {
 interface Props {
   editorProps: EditorProps;
   nickname: string | undefined;
-  mentionedList?: UserDBProps[];
 }
 
 interface UploadHooksProps {
   (params: FormSubmitProps): void;
 }
 
-const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) => {
+const useEditorLogicByProps = ({ editorProps, nickname }: Props) => {
   const [upload, setUpload] = useState<UploadHooksProps>(() => () => {});
 
   const { uploadThread } = useCreateThread({
@@ -87,7 +85,7 @@ const useEditorLogicByProps = ({ editorProps, nickname, mentionedList }: Props) 
     }
 
     setUpload(() => uploadThread);
-  }, [editorProps, mentionedList]);
+  }, [editorProps]);
 
   return { upload };
 };

--- a/src/hooks/api/useMentionNotification.ts
+++ b/src/hooks/api/useMentionNotification.ts
@@ -1,22 +1,25 @@
 import { usePostNotification } from "@/apis/notification/usePostNotification.ts";
 import { usePostMention } from "@/apis/mention/usePostMention.ts";
-import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import { NOTIFICATION_TYPES } from "@/constants/notification";
+import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 
 interface MentionNotificationProps {
+  mentionedList?: UserDBProps[];
   content: string;
   postId: string;
   channelName: string;
 }
 
-interface Props {
-  mentionedList?: UserDBProps[];
-}
-const useMentionNotification = ({ mentionedList }: Props) => {
+const useMentionNotification = () => {
   const { mutateAsync: mentionMutate } = usePostMention();
   const { mutate: notificationMutate } = usePostNotification();
 
-  const mentionNotification = ({ content, postId, channelName }: MentionNotificationProps) => {
+  const mentionNotification = ({
+    mentionedList,
+    content,
+    postId,
+    channelName,
+  }: MentionNotificationProps) => {
     if (!mentionedList) return;
 
     mentionedList.forEach(async (mentionUser) => {

--- a/src/hooks/api/useUpdateUserList.ts
+++ b/src/hooks/api/useUpdateUserList.ts
@@ -36,8 +36,10 @@ const useUpdateUserList = () => {
 
     try {
       await changeThread({
-        anonymous: false,
-        content: JSON.stringify(newUserList),
+        formValues: {
+          anonymous: false,
+          content: JSON.stringify(newUserList),
+        },
       });
     } catch (error) {
       logout();

--- a/src/hooks/api/useUploadComment.ts
+++ b/src/hooks/api/useUploadComment.ts
@@ -1,35 +1,26 @@
 import { usePostComment } from "@/apis/comment/usePostComment.ts";
 import { usePostNotification } from "@/apis/notification/usePostNotification.ts";
-import { FormValues } from "@/components/common/EditorTextArea.tsx";
 import { formJSONStringify } from "@/lib/editorContent.ts";
-import { UserDBProps } from "@/hooks/api/useUserListByDB.ts";
 import useMentionNotification from "@/hooks/api/useMentionNotification.ts";
 import { NOTIFICATION_TYPES } from "@/constants/notification";
 import usePostSlackMessage from "@/apis/slackBot/usePostSlackMessage.ts";
+import { FormSubmitProps } from "@/hooks/api/useCreateThread.ts";
 
 interface Props {
   nickname: string | undefined;
   postId: string;
   channelId: string;
   channelName: string;
-  mentionedList?: UserDBProps[];
   postAuthorId: string;
 }
 
-const useUploadComment = ({
-  nickname,
-  postId,
-  channelId,
-  channelName,
-  mentionedList,
-  postAuthorId,
-}: Props) => {
+const useUploadComment = ({ nickname, postId, channelId, channelName, postAuthorId }: Props) => {
   const { mutateAsync: commentMutate } = usePostComment(channelId);
   const { mutate: notificationMutate } = usePostNotification();
-  const { mentionNotification } = useMentionNotification({ mentionedList });
+  const { mentionNotification } = useMentionNotification();
   const { sendMessageBySlackBot } = usePostSlackMessage();
 
-  const uploadComment = async (formValues: FormValues) => {
+  const uploadComment = async ({ formValues, mentionedList }: FormSubmitProps) => {
     if (!formValues) return;
 
     const commentRequest = {


### PR DESCRIPTION
## 📝 작업 내용

EditorTextArea에 container-presentational 패턴 적용을 하려다보니 문제가 발생했습니다. 

onSubmit시 멘션리스트도 같이 보내야 하는데 기존의 멘션 리스트는 EditorTextArea.tsx내의 훅에서 props로 보내주기 때문에 가능했습니다.
하지만 패턴을 적용할 코드에서는 EditorTextArea.tsx 외부에서 onSubmit을 주입하기 때문에 props로 받을 수 없고

커스텀 훅의 Props로 mentionList를 받다보니 선언하는 시점에 mentionList가 없으면 쓸 수 없게되는 의존성이 생겼기 때문에 문제가 발생한 것입니다. 

이를 mentionNotification 함수의 props로 변경해서 커스텀 훅의 의존성을 제거하였습니다. 

그리고 기존에 타입가드로 분기처리를 해주던 useEditorLogicByProps.ts는 패턴 적용 후 사라질 훅 입니다! 

## 💬 리뷰 요구사항

편하게 말씀해주세요!


close #232 
